### PR TITLE
Add basic service client

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,3 +7,4 @@ linters:
     - gochecknoglobals
     - gosec
     - lll
+    - wsl

--- a/pkg/testutils/environment.go
+++ b/pkg/testutils/environment.go
@@ -1,0 +1,29 @@
+package testutils
+
+import (
+	"net/http"
+	"net/http/httptest"
+)
+
+// TestEnv represents a testing environment for all resources.
+type TestEnv struct {
+	Mux    *http.ServeMux
+	Server *httptest.Server
+}
+
+// SetupTestEnv prepares the new testing environment.
+func SetupTestEnv() *TestEnv {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	return &TestEnv{
+		Mux:    mux,
+		Server: server,
+	}
+}
+
+// TearDownTestEnv releases the testing environment.
+func (testEnv *TestEnv) TearDownTestEnv() {
+	testEnv.Server.Close()
+	testEnv.Server = nil
+	testEnv.Mux = nil
+}

--- a/pkg/v1/client.go
+++ b/pkg/v1/client.go
@@ -123,7 +123,7 @@ func (client *ServiceClient) DoRequest(ctx context.Context, method, path string,
 	}
 
 	// Check status code and populate custom error body with extended error message if it's possible.
-	if response.StatusCode >= 400 && response.StatusCode <= 599 {
+	if response.StatusCode >= http.StatusBadRequest {
 		err = responseResult.extractErr()
 	}
 	if err != nil {
@@ -168,14 +168,12 @@ type ErrGeneric struct {
 // ExtractResult allows to provide an object into which ResponseResult body will be extracted.
 func (result *ResponseResult) ExtractResult(to interface{}) error {
 	body, err := ioutil.ReadAll(result.Body)
-	defer result.Body.Close()
 	if err != nil {
 		return err
 	}
+	defer result.Body.Close()
 
-	err = json.Unmarshal(body, to)
-
-	return err
+	return json.Unmarshal(body, to)
 }
 
 // extractErr populates an error message and error structure in the ResponseResult body.
@@ -186,7 +184,7 @@ func (result *ResponseResult) extractErr() error {
 		return err
 	}
 
-	if result.StatusCode == 404 {
+	if result.StatusCode == http.StatusNotFound {
 		err = json.Unmarshal(body, &result.ErrNotFound)
 	} else {
 		err = json.Unmarshal(body, &result.ErrGeneric)

--- a/pkg/v1/client.go
+++ b/pkg/v1/client.go
@@ -1,1 +1,201 @@
 package v1
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"time"
+)
+
+const (
+	// appName represents an application name.
+	appName = "mks-go"
+
+	// appVersion is a version of the application.
+	appVersion = "0.1.0"
+
+	// userAgent contains a basic user agent that will be used in queries.
+	userAgent = appName + "/" + appVersion
+
+	// defaultHTTPTimeout represents the default timeout (in seconds) for HTTP requests.
+	defaultHTTPTimeout = 120
+
+	// defaultDialTimeout represents the default timeout (in seconds) for HTTP connection establishments.
+	defaultDialTimeout = 60
+
+	// defaultKeepaliveTimeout represents the default keep-alive period for an active network connection.
+	defaultKeepaliveTimeout = 60
+
+	// defaultMaxIdleConns represents the maximum number of idle (keep-alive) connections.
+	defaultMaxIdleConns = 100
+
+	// defaultIdleConnTimeout represents the maximum amount of time an idle (keep-alive) connection will remain
+	// idle before closing itself.
+	defaultIdleConnTimeout = 100
+
+	// defaultTLSHandshakeTimeout represents the default timeout (in seconds) for TLS handshake.
+	defaultTLSHandshakeTimeout = 60
+
+	// defaultExpectContinueTimeout represents the default amount of time to wait for a server's first
+	// response headers.
+	defaultExpectContinueTimeout = 1
+)
+
+// ServiceClient stores details that are needed to work with Selectel Managed Kubernetes Service API.
+type ServiceClient struct {
+	// HTTPClient represents an initialized HTTP client that will be used to do requests.
+	HTTPClient *http.Client
+
+	// TokenID is a client authentication token.
+	TokenID string
+
+	// Endpoint represents an endpoint that will be used in all requests.
+	Endpoint string
+
+	// UserAgent contains user agent that will be used in all requests.
+	UserAgent string
+}
+
+// NewMKSClientV1 initializes a new MKS client for the V1 API.
+func NewMKSClientV1(tokenID, endpoint string) *ServiceClient {
+	return &ServiceClient{
+		HTTPClient: newHTTPClient(),
+		TokenID:    tokenID,
+		Endpoint:   endpoint,
+		UserAgent:  userAgent,
+	}
+}
+
+// newHTTPClient returns a reference to an initialized and configured HTTP client.
+func newHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout:   defaultHTTPTimeout * time.Second,
+		Transport: newHTTPTransport(),
+	}
+}
+
+// newHTTPTransport returns a reference to an initialized and configured HTTP transport.
+func newHTTPTransport() *http.Transport {
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   defaultDialTimeout * time.Second,
+			KeepAlive: defaultKeepaliveTimeout * time.Second,
+		}).DialContext,
+		MaxIdleConns:          defaultMaxIdleConns,
+		IdleConnTimeout:       defaultIdleConnTimeout * time.Second,
+		TLSHandshakeTimeout:   defaultTLSHandshakeTimeout * time.Second,
+		ExpectContinueTimeout: defaultExpectContinueTimeout * time.Second,
+	}
+}
+
+// DoRequest performs the HTTP request with the current ServiceClient's HTTPClient.
+// Authentication and optional headers will be added automatically.
+func (client *ServiceClient) DoRequest(ctx context.Context, method, path string, body io.Reader) (*ResponseResult, error) {
+	// Prepare an HTTP request with the provided context.
+	request, err := http.NewRequest(method, path, body)
+	if err != nil {
+		return nil, err
+	}
+
+	request.Header.Set("User-Agent", client.UserAgent)
+	request.Header.Set("X-Auth-Token", client.TokenID)
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	request = request.WithContext(ctx)
+
+	// Send the HTTP request and populate the ResponseResult.
+	response, err := client.HTTPClient.Do(request)
+	if err != nil {
+		return nil, err
+	}
+
+	responseResult := &ResponseResult{
+		Response:    response,
+		ErrNotFound: nil,
+		ErrGeneric:  nil,
+		Err:         nil,
+	}
+
+	// Check status code and populate custom error body with extended error message if it's possible.
+	if response.StatusCode >= 400 && response.StatusCode <= 599 {
+		err = responseResult.extractErr()
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return responseResult, nil
+}
+
+// ResponseResult represents a result of an HTTP request.
+// It embeds standard http.Response and adds custom API error representations.
+type ResponseResult struct {
+	*http.Response
+
+	*ErrNotFound
+
+	*ErrGeneric
+
+	// Err contains an error that can be provided to a caller.
+	Err error
+}
+
+// ErrNotFound represents 'not found' error of an HTTP response.
+type ErrNotFound struct {
+	Error struct {
+		// Object ID.
+		ID string `json:"id"`
+
+		// Message of the error.
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// ErrGeneric represents a generic error of an HTTP response.
+type ErrGeneric struct {
+	Error struct {
+		// Message of the error.
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// ExtractResult allows to provide an object into which ResponseResult body will be extracted.
+func (result *ResponseResult) ExtractResult(to interface{}) error {
+	body, err := ioutil.ReadAll(result.Body)
+	defer result.Body.Close()
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(body, to)
+
+	return err
+}
+
+// extractErr populates an error message and error structure in the ResponseResult body.
+func (result *ResponseResult) extractErr() error {
+	body, err := ioutil.ReadAll(result.Body)
+	defer result.Body.Close()
+	if err != nil {
+		return err
+	}
+
+	if result.StatusCode == 404 {
+		err = json.Unmarshal(body, &result.ErrNotFound)
+	} else {
+		err = json.Unmarshal(body, &result.ErrGeneric)
+	}
+	if err != nil {
+		return err
+	}
+
+	result.Err = fmt.Errorf("mks-go: got the %d status code from the server: %s", result.StatusCode, string(body))
+
+	return nil
+}

--- a/pkg/v1/client.go
+++ b/pkg/v1/client.go
@@ -179,10 +179,10 @@ func (result *ResponseResult) ExtractResult(to interface{}) error {
 // extractErr populates an error message and error structure in the ResponseResult body.
 func (result *ResponseResult) extractErr() error {
 	body, err := ioutil.ReadAll(result.Body)
-	defer result.Body.Close()
 	if err != nil {
 		return err
 	}
+	defer result.Body.Close()
 
 	if result.StatusCode == http.StatusNotFound {
 		err = json.Unmarshal(body, &result.ErrNotFound)

--- a/pkg/v1/client_test.go
+++ b/pkg/v1/client_test.go
@@ -65,7 +65,7 @@ func TestDoGetRequest(t *testing.T) {
 	if response.Body == nil {
 		t.Fatal("response body is empty")
 	}
-	if response.StatusCode != 200 {
+	if response.StatusCode != http.StatusOK {
 		t.Fatalf("got %d response status, want 200", response.StatusCode)
 	}
 }
@@ -112,7 +112,7 @@ func TestDoPostRequest(t *testing.T) {
 	if response.Body == nil {
 		t.Fatal("response body is empty")
 	}
-	if response.StatusCode != 200 {
+	if response.StatusCode != http.StatusOK {
 		t.Fatalf("got %d response status, want 200", response.StatusCode)
 	}
 }
@@ -122,7 +122,7 @@ func TestDoErrNotFoundRequest(t *testing.T) {
 	defer testEnv.TearDownTestEnv()
 	testEnv.Mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Content-Type", "application/json")
-		w.WriteHeader(404)
+		w.WriteHeader(http.StatusNotFound)
 		fmt.Fprint(w, `{"error":{"id":"9fb12d6e-0da2-4db1-a076-414059cfb448","message":"Cluster not found"}}`)
 
 		if r.Method != http.MethodGet {
@@ -146,7 +146,7 @@ func TestDoErrNotFoundRequest(t *testing.T) {
 	if response.Body == nil {
 		t.Fatal("response body is empty")
 	}
-	if response.StatusCode != 404 {
+	if response.StatusCode != http.StatusNotFound {
 		t.Fatalf("got %d response status, want 404", response.StatusCode)
 	}
 
@@ -164,7 +164,7 @@ func TestDoErrGenericRequest(t *testing.T) {
 	defer testEnv.TearDownTestEnv()
 	testEnv.Mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Content-Type", "application/json")
-		w.WriteHeader(400)
+		w.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(w, `{"error":{"message":"cluster_id value is invalid"}}`)
 
 		if r.Method != http.MethodGet {
@@ -188,7 +188,7 @@ func TestDoErrGenericRequest(t *testing.T) {
 	if response.Body == nil {
 		t.Fatal("response body is empty")
 	}
-	if response.StatusCode != 400 {
+	if response.StatusCode != http.StatusBadRequest {
 		t.Fatalf("got %d response status, want 400", response.StatusCode)
 	}
 

--- a/pkg/v1/client_test.go
+++ b/pkg/v1/client_test.go
@@ -1,1 +1,198 @@
 package v1
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/selectel/mks-go/pkg/testutils"
+)
+
+func TestNewMKSClientV1(t *testing.T) {
+	tokenID := "fakeID"
+	endpoint := "http://example.org"
+	expected := &ServiceClient{
+		TokenID:   tokenID,
+		Endpoint:  endpoint,
+		UserAgent: userAgent,
+	}
+
+	actual := NewMKSClientV1(tokenID, endpoint)
+
+	if expected.TokenID != actual.TokenID {
+		t.Errorf("expected Endpoint %s, but got %s", expected.Endpoint, actual.Endpoint)
+	}
+	if expected.Endpoint != actual.Endpoint {
+		t.Errorf("expected TokenID %s, but got %s", expected.TokenID, actual.TokenID)
+	}
+	if expected.UserAgent != actual.UserAgent {
+		t.Errorf("expected UserAgent %s, but got %s", expected.UserAgent, actual.UserAgent)
+	}
+	if actual.HTTPClient == nil {
+		t.Errorf("expected initialized HTTPClient but it's nil")
+	}
+}
+
+func TestDoGetRequest(t *testing.T) {
+	testEnv := testutils.SetupTestEnv()
+	defer testEnv.TearDownTestEnv()
+	testEnv.Mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, "response")
+
+		if r.Method != http.MethodGet {
+			t.Errorf("got %s method, want GET", r.Method)
+		}
+	})
+
+	endpoint := testEnv.Server.URL + "/"
+	client := &ServiceClient{
+		HTTPClient: &http.Client{},
+		Endpoint:   endpoint,
+		TokenID:    "token",
+		UserAgent:  "agent",
+	}
+
+	ctx := context.Background()
+	response, err := client.DoRequest(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if response.Body == nil {
+		t.Fatal("response body is empty")
+	}
+	if response.StatusCode != 200 {
+		t.Fatalf("got %d response status, want 200", response.StatusCode)
+	}
+}
+
+func TestDoPostRequest(t *testing.T) {
+	testEnv := testutils.SetupTestEnv()
+	defer testEnv.TearDownTestEnv()
+	testEnv.Mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, "response")
+
+		if r.Method != http.MethodPost {
+			t.Errorf("got %s method, want POST", r.Method)
+		}
+
+		_, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("unable to read the request body: %v", err)
+		}
+	})
+
+	endpoint := testEnv.Server.URL + "/"
+	client := &ServiceClient{
+		HTTPClient: &http.Client{},
+		Endpoint:   endpoint,
+		TokenID:    "token",
+		UserAgent:  "agent",
+	}
+
+	requestBody, err := json.Marshal(&struct {
+		ID string `json:"id"`
+	}{
+		ID: "uuid",
+	})
+	if err != nil {
+		t.Fatalf("can't marshal JSON: %v", err)
+	}
+
+	ctx := context.Background()
+	response, err := client.DoRequest(ctx, http.MethodPost, endpoint, bytes.NewReader(requestBody))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if response.Body == nil {
+		t.Fatal("response body is empty")
+	}
+	if response.StatusCode != 200 {
+		t.Fatalf("got %d response status, want 200", response.StatusCode)
+	}
+}
+
+func TestDoErrNotFoundRequest(t *testing.T) {
+	testEnv := testutils.SetupTestEnv()
+	defer testEnv.TearDownTestEnv()
+	testEnv.Mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(404)
+		fmt.Fprint(w, `{"error":{"id":"9fb12d6e-0da2-4db1-a076-414059cfb448","message":"Cluster not found"}}`)
+
+		if r.Method != http.MethodGet {
+			t.Errorf("got %s method, want GET", r.Method)
+		}
+	})
+
+	endpoint := testEnv.Server.URL + "/"
+	client := &ServiceClient{
+		HTTPClient: &http.Client{},
+		Endpoint:   endpoint,
+		TokenID:    "token",
+		UserAgent:  "agent",
+	}
+
+	ctx := context.Background()
+	response, err := client.DoRequest(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if response.Body == nil {
+		t.Fatal("response body is empty")
+	}
+	if response.StatusCode != 404 {
+		t.Fatalf("got %d response status, want 404", response.StatusCode)
+	}
+
+	if response.ErrNotFound.Error.Message != "Cluster not found" {
+		t.Fatalf("got %s error message, want 'Cluster not found'", response.ErrNotFound.Error.Message)
+	}
+
+	if response.ErrNotFound.Error.ID != "9fb12d6e-0da2-4db1-a076-414059cfb448" {
+		t.Fatalf("got %s object id, want '9fb12d6e-0da2-4db1-a076-414059cfb448'", response.ErrNotFound.Error.ID)
+	}
+}
+
+func TestDoErrGenericRequest(t *testing.T) {
+	testEnv := testutils.SetupTestEnv()
+	defer testEnv.TearDownTestEnv()
+	testEnv.Mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(400)
+		fmt.Fprint(w, `{"error":{"message":"cluster_id value is invalid"}}`)
+
+		if r.Method != http.MethodGet {
+			t.Errorf("got %s method, want GET", r.Method)
+		}
+	})
+
+	endpoint := testEnv.Server.URL + "/"
+	client := &ServiceClient{
+		HTTPClient: &http.Client{},
+		Endpoint:   endpoint,
+		TokenID:    "token",
+		UserAgent:  "agent",
+	}
+
+	ctx := context.Background()
+	response, err := client.DoRequest(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if response.Body == nil {
+		t.Fatal("response body is empty")
+	}
+	if response.StatusCode != 400 {
+		t.Fatalf("got %d response status, want 400", response.StatusCode)
+	}
+
+	if response.ErrGeneric.Error.Message != "cluster_id value is invalid" {
+		t.Fatalf("got %s error message, want 'cluster_id value is invalid'", response.ErrGeneric.Error.Message)
+	}
+}

--- a/pkg/v1/doc.go
+++ b/pkg/v1/doc.go
@@ -1,1 +1,4 @@
+/*
+Package v1 provides a library to work with the Selectel Managed Kubernetes Service API V1.
+*/
 package v1


### PR DESCRIPTION
Add client with basic methods and structures that will be used by all
subpackages of the mks-go library.

Also this commit disables wsl linter in .golangci.yml.

For #2 
