### PR TITLE
Fix error handling with empty response body

### DIFF
--- a/pkg/v1/client.go
+++ b/pkg/v1/client.go
@@ -188,6 +188,10 @@ func (result *ResponseResult) extractErr() error {
 	}
 	defer result.Body.Close()
 
+	if len(body) == 0 {
+		result.Err = fmt.Errorf("mks-go: got the %d status code from the server", result.StatusCode)
+		return nil
+	}
 	if result.StatusCode == http.StatusNotFound {
 		err = json.Unmarshal(body, &result.ErrNotFound)
 	} else {


### PR DESCRIPTION
Update extractErr function in v1 package to handle errors with
empty response body properly. Provide test.

For #2
