### PR TITLE
Cluster V1 - add cluster get kubeconfig method

### DIFF
--- a/pkg/v1/client.go
+++ b/pkg/v1/client.go
@@ -12,7 +12,8 @@ import (
 )
 
 const (
-	ResourceURLCluster = "clusters"
+	ResourceURLCluster    = "clusters"
+	ResourceURLKubeconfig = "kubeconfig"
 )
 
 const (
@@ -178,6 +179,17 @@ func (result *ResponseResult) ExtractResult(to interface{}) error {
 	defer result.Body.Close()
 
 	return json.Unmarshal(body, to)
+}
+
+// ExtractRaw extracts ResponseResult body into the slice of bytes without unmarshalling.
+func (result *ResponseResult) ExtractRaw() ([]byte, error) {
+	bytes, err := ioutil.ReadAll(result.Body)
+	if err != nil {
+		return nil, err
+	}
+	defer result.Body.Close()
+
+	return bytes, nil
 }
 
 // extractErr populates an error message and error structure in the ResponseResult body.

--- a/pkg/v1/cluster/doc.go
+++ b/pkg/v1/cluster/doc.go
@@ -50,5 +50,13 @@ Example of deleting a single cluster
   if err != nil {
     log.Fatal(err)
   }
+
+Example of getting a kubeconfig referenced by cluster id
+
+  kubeconfig, _, err := cluster.GetKubeconfig(ctx, mksClient, id)
+  if err != nil {
+    log.Fatal(err)
+  }
+  fmt.Print(string(kubeconfig))
 */
 package cluster

--- a/pkg/v1/cluster/requests.go
+++ b/pkg/v1/cluster/requests.go
@@ -10,7 +10,7 @@ import (
 	v1 "github.com/selectel/mks-go/pkg/v1"
 )
 
-// Get returns a single Cluster by its id.
+// Get returns a single cluster by its id.
 func Get(ctx context.Context, client *v1.ServiceClient, id string) (*View, *v1.ResponseResult, error) {
 	url := strings.Join([]string{client.Endpoint, v1.ResourceURLCluster, id}, "/")
 	responseResult, err := client.DoRequest(ctx, http.MethodGet, url, nil)
@@ -101,4 +101,24 @@ func Delete(ctx context.Context, client *v1.ServiceClient, id string) (*v1.Respo
 	}
 
 	return responseResult, err
+}
+
+// GetKubeconfig returns a kubeconfig by cluster id.
+func GetKubeconfig(ctx context.Context, client *v1.ServiceClient, id string) ([]byte, *v1.ResponseResult, error) {
+	url := strings.Join([]string{client.Endpoint, v1.ResourceURLCluster, id, v1.ResourceURLKubeconfig}, "/")
+	responseResult, err := client.DoRequest(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	if responseResult.Err != nil {
+		return nil, responseResult, responseResult.Err
+	}
+
+	// Extract kubeconfig from the response body.
+	kubeconfig, err := responseResult.ExtractRaw()
+	if err != nil {
+		return nil, responseResult, err
+	}
+
+	return kubeconfig, responseResult, nil
 }

--- a/pkg/v1/cluster/testing/fixtures.go
+++ b/pkg/v1/cluster/testing/fixtures.go
@@ -207,3 +207,28 @@ const testSingleClusterInvalidResponseRaw = `
     }
 }
 `
+
+// testErrGenericResponseRaw represents a raw response with an error in the generic format.
+const testErrGenericResponseRaw = `{"error":{"message":"bad gateway"}}`
+
+// testGetKubeconfig represents a raw response from the GetKubeconfig request.
+const testGetKubeconfig = `apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tS0tLQo=
+    server: https://203.0.113.101:6443
+  name: kubernetes
+contexts:
+- context:
+    cluster: kubernetes
+    user: admin
+  name: admin@kubernetes
+current-context: admin@kubernetes
+kind: Config
+preferences: {}
+users:
+- name: admin
+  user:
+    client-certificate-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tS0tLQo=
+    client-key-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tS0tLQo=
+`


### PR DESCRIPTION
Add method to get kubeconfig of the specified cluster.
Fix HTTPError test responses in the cluster/testing package.
Provide tests and doc example.

For #2 
