### PR TITLE
Fix: make certain resource URL constants private

### DIFF
--- a/pkg/v1/client.go
+++ b/pkg/v1/client.go
@@ -12,9 +12,7 @@ import (
 )
 
 const (
-	ResourceURLCluster     = "clusters"
-	ResourceURLKubeconfig  = "kubeconfig"
-	ResourceURLRotateCerts = "rotate-certs"
+	ResourceURLCluster = "clusters"
 )
 
 const (

--- a/pkg/v1/cluster/requests.go
+++ b/pkg/v1/cluster/requests.go
@@ -10,6 +10,11 @@ import (
 	v1 "github.com/selectel/mks-go/pkg/v1"
 )
 
+const (
+	resourceURLKubeconfig  = "kubeconfig"
+	resourceURLRotateCerts = "rotate-certs"
+)
+
 // Get returns a single cluster by its id.
 func Get(ctx context.Context, client *v1.ServiceClient, id string) (*View, *v1.ResponseResult, error) {
 	url := strings.Join([]string{client.Endpoint, v1.ResourceURLCluster, id}, "/")
@@ -105,7 +110,7 @@ func Delete(ctx context.Context, client *v1.ServiceClient, id string) (*v1.Respo
 
 // GetKubeconfig returns a kubeconfig by cluster id.
 func GetKubeconfig(ctx context.Context, client *v1.ServiceClient, id string) ([]byte, *v1.ResponseResult, error) {
-	url := strings.Join([]string{client.Endpoint, v1.ResourceURLCluster, id, v1.ResourceURLKubeconfig}, "/")
+	url := strings.Join([]string{client.Endpoint, v1.ResourceURLCluster, id, resourceURLKubeconfig}, "/")
 	responseResult, err := client.DoRequest(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, nil, err
@@ -125,7 +130,7 @@ func GetKubeconfig(ctx context.Context, client *v1.ServiceClient, id string) ([]
 
 // RotateCerts requests a rotation of cluster certificates by cluster id.
 func RotateCerts(ctx context.Context, client *v1.ServiceClient, id string) (*v1.ResponseResult, error) {
-	url := strings.Join([]string{client.Endpoint, v1.ResourceURLCluster, id, v1.ResourceURLRotateCerts}, "/")
+	url := strings.Join([]string{client.Endpoint, v1.ResourceURLCluster, id, resourceURLRotateCerts}, "/")
 	responseResult, err := client.DoRequest(ctx, http.MethodPost, url, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Move certain resource URL constants from the v1 package into the
cluster package and make them private.

For #2 
