### PR TITLE
Cluster V1 - add nodegroup Get method

### DIFF
--- a/pkg/v1/client.go
+++ b/pkg/v1/client.go
@@ -17,6 +17,7 @@ const (
 	ResourceURLKubeconfig  = "kubeconfig"
 	ResourceURLRotateCerts = "rotate-certs"
 	ResourceURLTask        = "tasks"
+	ResourceURLNodegroup   = "nodegroups"
 )
 
 const (

--- a/pkg/v1/node/doc.go
+++ b/pkg/v1/node/doc.go
@@ -1,0 +1,1 @@
+package node

--- a/pkg/v1/node/doc.go
+++ b/pkg/v1/node/doc.go
@@ -1,1 +1,5 @@
+/*
+Package node provides the ability to retrieve and manage Kubernetes nodes
+of a cluster nodegroup through the MKS V1 API.
+*/
 package node

--- a/pkg/v1/node/requests.go
+++ b/pkg/v1/node/requests.go
@@ -1,0 +1,1 @@
+package node

--- a/pkg/v1/node/schemas.go
+++ b/pkg/v1/node/schemas.go
@@ -1,0 +1,24 @@
+package node
+
+import "time"
+
+// View represents an unmarshalled node body from an API response.
+type View struct {
+	// ID is the identifier of the node.
+	ID string `json:"id"`
+
+	// CreatedAt is the timestamp in UTC timezone of when the node has been created.
+	CreatedAt *time.Time `json:"created_at"`
+
+	// UpdatedAt is the timestamp in UTC timezone of when the node has been updated.
+	UpdatedAt *time.Time `json:"updated_at"`
+
+	// Hostname represents a hostname of the node.
+	Hostname string `json:"hostname"`
+
+	// IP represents IP address of the node.
+	IP string `json:"ip"`
+
+	// NodegroupID contains nodegroup identifier.
+	NodegroupID string `json:"nodegroup_id"`
+}

--- a/pkg/v1/node/testing/fixtures.go
+++ b/pkg/v1/node/testing/fixtures.go
@@ -1,0 +1,1 @@
+package testing

--- a/pkg/v1/node/testing/requests_test.go
+++ b/pkg/v1/node/testing/requests_test.go
@@ -1,0 +1,1 @@
+package testing

--- a/pkg/v1/nodegroup/doc.go
+++ b/pkg/v1/nodegroup/doc.go
@@ -1,1 +1,13 @@
+/*
+Package nodegroup provides the ability to retrieve and manage cluster nodegroups
+through the MKS V1 API.
+
+Example of getting a single cluster nodegroup referenced by its id
+
+  clusterNodegroup, _, err := nodegroup.Get(ctx, mksClient, clusterID, nodegroupID)
+  if err != nil {
+    log.Fatal(err)
+  }
+  fmt.Printf("%+v\n", clusterNodegroup)
+*/
 package nodegroup

--- a/pkg/v1/nodegroup/requests.go
+++ b/pkg/v1/nodegroup/requests.go
@@ -1,1 +1,32 @@
 package nodegroup
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	v1 "github.com/selectel/mks-go/pkg/v1"
+)
+
+// Get returns a cluster nodegroup by its id.
+func Get(ctx context.Context, client *v1.ServiceClient, clusterID, nodegroupID string) (*View, *v1.ResponseResult, error) {
+	url := strings.Join([]string{client.Endpoint, v1.ResourceURLCluster, clusterID, v1.ResourceURLNodegroup, nodegroupID}, "/")
+	responseResult, err := client.DoRequest(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	if responseResult.Err != nil {
+		return nil, responseResult, responseResult.Err
+	}
+
+	// Extract a nodegroup to the response body.
+	var result struct {
+		Nodegroup *View `json:"nodegroup"`
+	}
+	err = responseResult.ExtractResult(&result)
+	if err != nil {
+		return nil, responseResult, err
+	}
+
+	return result.Nodegroup, responseResult, err
+}

--- a/pkg/v1/nodegroup/schemas.go
+++ b/pkg/v1/nodegroup/schemas.go
@@ -1,1 +1,40 @@
 package nodegroup
+
+import (
+	"time"
+
+	"github.com/selectel/mks-go/pkg/v1/node"
+)
+
+// View represents an unmarshalled nodegroup body from an API response.
+type View struct {
+	// ID is the identifier of the nodegroup.
+	ID string `json:"id"`
+
+	// CreatedAt is the timestamp in UTC timezone of when the nodegroup has been created.
+	CreatedAt *time.Time `json:"created_at"`
+
+	// UpdatedAt is the timestamp in UTC timezone of when the nodegroup has been updated.
+	UpdatedAt *time.Time `json:"updated_at"`
+
+	// ClusterID contains cluster identifier.
+	ClusterID string `json:"cluster_id"`
+
+	// FlavorID contains OpenStack flavor identifier for all nodes in the nodegroup.
+	FlavorID string `json:"flavor_id"`
+
+	// VolumeGB represents initial volume size in GB for each node.
+	VolumeGB int `json:"volume_gb"`
+
+	// VolumeType represents initial blockstorage volume type for each node.
+	VolumeType string `json:"volume_type"`
+
+	// LocalVolume represents if nodes use local volume.
+	LocalVolume bool `json:"local_volume"`
+
+	// AvailabilityZone represents OpenStack availability zone for all nodes in the nodegroup.
+	AvailabilityZone string `json:"availability_zone"`
+
+	// Nodes contains list of all nodes in the nodegroup.
+	Nodes []*node.View `json:"nodes"`
+}

--- a/pkg/v1/nodegroup/testing/fixtures.go
+++ b/pkg/v1/nodegroup/testing/fixtures.go
@@ -1,1 +1,73 @@
 package testing
+
+import (
+	"time"
+
+	"github.com/selectel/mks-go/pkg/v1/node"
+	"github.com/selectel/mks-go/pkg/v1/nodegroup"
+)
+
+// testGetNodegroupResponseRaw represents a raw response from the Get request.
+const testGetNodegroupResponseRaw = `
+{
+    "nodegroup": {
+        "availability_zone": "ru-1a",
+        "cluster_id": "79265515-3700-49fa-af0e-7f547bce788a",
+        "created_at": "2020-02-19T15:41:45.948646Z",
+        "flavor_id": "99b62670-9d78-43fd-8f55-d184a4800f8d",
+        "id": "a376745a-fbcb-413d-b418-169d059d79ce",
+        "local_volume": false,
+        "nodes": [
+            {
+                "created_at": "2020-02-19T15:41:45.948646Z",
+                "hostname": "test-cluster-node-eegp9",
+                "id": "39e5dd4d-5e23-4a00-8173-974bf844f21b",
+                "ip": "198.51.100.11",
+                "nodegroup_id": "a376745a-fbcb-413d-b418-169d059d79ce",
+                "updated_at": "2020-02-19T15:41:45.948646Z"
+            }
+        ],
+        "updated_at": "2020-02-19T15:41:45.948646Z",
+        "volume_gb": 10,
+        "volume_type": "basic.ru-1a"
+    }
+}
+`
+
+var nodegroupResponseTimestamp, _ = time.Parse(time.RFC3339, "2020-02-19T15:41:45.948646Z")
+
+// nolint
+// expectedGetNodegroupResponse represents an unmarshalled testGetNodegroupResponseRaw.
+var expectedGetNodegroupResponse = &nodegroup.View{
+	ID:               "a376745a-fbcb-413d-b418-169d059d79ce",
+	CreatedAt:        &nodegroupResponseTimestamp,
+	UpdatedAt:        &nodegroupResponseTimestamp,
+	ClusterID:        "79265515-3700-49fa-af0e-7f547bce788a",
+	FlavorID:         "99b62670-9d78-43fd-8f55-d184a4800f8d",
+	VolumeGB:         10,
+	VolumeType:       "basic.ru-1a",
+	LocalVolume:      false,
+	AvailabilityZone: "ru-1a",
+	Nodes: []*node.View{
+		{
+			ID:          "39e5dd4d-5e23-4a00-8173-974bf844f21b",
+			CreatedAt:   &nodegroupResponseTimestamp,
+			UpdatedAt:   &nodegroupResponseTimestamp,
+			Hostname:    "test-cluster-node-eegp9",
+			IP:          "198.51.100.11",
+			NodegroupID: "a376745a-fbcb-413d-b418-169d059d79ce",
+		},
+	},
+}
+
+// testSingleNodegroupInvalidResponseRaw represents a raw invalid response with a single nodegroup.
+const testSingleNodegroupInvalidResponseRaw = `
+{
+    "nodegroup": {
+        "id": "a376745a-fbcb-413d-b418-169d059d79ce",
+    }
+}
+`
+
+// testErrGenericResponseRaw represents a raw response with an error in the generic format.
+const testErrGenericResponseRaw = `{"error":{"message":"bad gateway"}}`

--- a/pkg/v1/nodegroup/testing/requests_test.go
+++ b/pkg/v1/nodegroup/testing/requests_test.go
@@ -1,1 +1,168 @@
 package testing
+
+import (
+	"context"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/selectel/mks-go/pkg/testutils"
+	v1 "github.com/selectel/mks-go/pkg/v1"
+	"github.com/selectel/mks-go/pkg/v1/nodegroup"
+)
+
+func TestGetNodegroup(t *testing.T) {
+	endpointCalled := false
+	testEnv := testutils.SetupTestEnv()
+	defer testEnv.TearDownTestEnv()
+
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/v1/clusters/79265515-3700-49fa-af0e-7f547bce788a/nodegroups/a376745a-fbcb-413d-b418-169d059d79ce",
+		RawResponse: testGetNodegroupResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
+
+	ctx := context.Background()
+	testClient := &v1.ServiceClient{
+		HTTPClient: &http.Client{},
+		TokenID:    testutils.TokenID,
+		Endpoint:   testEnv.Server.URL + "/v1",
+		UserAgent:  testutils.UserAgent,
+	}
+	clusterID := "79265515-3700-49fa-af0e-7f547bce788a"
+	nodegroupID := "a376745a-fbcb-413d-b418-169d059d79ce"
+
+	actual, httpResponse, err := nodegroup.Get(ctx, testClient, clusterID, nodegroupID)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !endpointCalled {
+		t.Fatal("endpoint wasn't called")
+	}
+	if httpResponse == nil {
+		t.Fatal("expected an HTTP response from the Get method")
+	}
+	if httpResponse.StatusCode != http.StatusOK {
+		t.Fatalf("expected %d status in the HTTP response, but got %d",
+			http.StatusOK, httpResponse.StatusCode)
+	}
+	if !reflect.DeepEqual(expectedGetNodegroupResponse, actual) {
+		t.Fatalf("expected %#v, but got %#v", expectedGetNodegroupResponse, actual)
+	}
+}
+
+func TestGetNodegroupHTTPError(t *testing.T) {
+	endpointCalled := false
+	testEnv := testutils.SetupTestEnv()
+	defer testEnv.TearDownTestEnv()
+
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/v1/clusters/79265515-3700-49fa-af0e-7f547bce777a/nodegroups/a376745a-fbcb-413d-b418-172d059d79ce",
+		RawResponse: testErrGenericResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusBadGateway,
+		CallFlag:    &endpointCalled,
+	})
+
+	ctx := context.Background()
+	testClient := &v1.ServiceClient{
+		HTTPClient: &http.Client{},
+		TokenID:    testutils.TokenID,
+		Endpoint:   testEnv.Server.URL + "/v1",
+		UserAgent:  testutils.UserAgent,
+	}
+	clusterID := "79265515-3700-49fa-af0e-7f547bce777a"
+	nodegroupID := "a376745a-fbcb-413d-b418-172d059d79ce"
+
+	actual, httpResponse, err := nodegroup.Get(ctx, testClient, clusterID, nodegroupID)
+
+	if !endpointCalled {
+		t.Fatal("endpoint wasn't called")
+	}
+	if actual != nil {
+		t.Fatal("expected no nodegroup from the Get method")
+	}
+	if httpResponse == nil {
+		t.Fatal("expected an HTTP response from the Get method")
+	}
+	if err == nil {
+		t.Fatal("expected error from the Get method")
+	}
+	if httpResponse.StatusCode != http.StatusBadGateway {
+		t.Fatalf("expected %d status in the HTTP response, but got %d",
+			http.StatusBadGateway, httpResponse.StatusCode)
+	}
+}
+
+func TestGetNodegroupTimeoutError(t *testing.T) {
+	testEnv := testutils.SetupTestEnv()
+	testEnv.Server.Close()
+	defer testEnv.TearDownTestEnv()
+
+	ctx := context.Background()
+	testClient := &v1.ServiceClient{
+		HTTPClient: &http.Client{},
+		TokenID:    testutils.TokenID,
+		Endpoint:   testEnv.Server.URL + "/v1",
+		UserAgent:  testutils.UserAgent,
+	}
+	clusterID := "79265515-3700-49fa-af0e-7f547bce888a"
+	nodegroupID := "a481745a-fbcb-413d-b418-172d059d79ce"
+
+	actual, httpResponse, err := nodegroup.Get(ctx, testClient, clusterID, nodegroupID)
+
+	if actual != nil {
+		t.Fatal("expected no nodegroup from the Get method")
+	}
+	if httpResponse != nil {
+		t.Fatal("expected no HTTP response from the Get method")
+	}
+	if err == nil {
+		t.Fatal("expected error from the Get method")
+	}
+}
+
+func TestGetNodegroupUnmarshallError(t *testing.T) {
+	endpointCalled := false
+	testEnv := testutils.SetupTestEnv()
+	defer testEnv.TearDownTestEnv()
+
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/v1/clusters/15965515-3700-49fa-af0e-7f547bce788a/nodegroups/a371145a-fbcb-413d-b418-169d059d79ce",
+		RawResponse: testSingleNodegroupInvalidResponseRaw,
+		Method:      http.MethodGet,
+		Status:      http.StatusOK,
+		CallFlag:    &endpointCalled,
+	})
+
+	ctx := context.Background()
+	testClient := &v1.ServiceClient{
+		HTTPClient: &http.Client{},
+		TokenID:    testutils.TokenID,
+		Endpoint:   testEnv.Server.URL + "/v1",
+		UserAgent:  testutils.UserAgent,
+	}
+	clusterID := "15965515-3700-49fa-af0e-7f547bce788a"
+	nodegroupID := "a371145a-fbcb-413d-b418-169d059d79ce"
+
+	actual, httpResponse, err := nodegroup.Get(ctx, testClient, clusterID, nodegroupID)
+
+	if !endpointCalled {
+		t.Fatal("endpoint wasn't called")
+	}
+	if actual != nil {
+		t.Fatal("expected no nodegroup from the Get method")
+	}
+	if httpResponse == nil {
+		t.Fatal("expected an HTTP response from the Get method")
+	}
+	if err == nil {
+		t.Fatal("expected error from the Get method")
+	}
+}


### PR DESCRIPTION
Add method to get a single cluster nodegroup.
Add node package with basic structure and schema representation.
Provide tests and doc example.

For #2 
