### PR TITLE
Cluster V1 - add nodegroup Delete method

### DIFF
--- a/pkg/v1/nodegroup/doc.go
+++ b/pkg/v1/nodegroup/doc.go
@@ -35,5 +35,12 @@ Example of creating a new cluster nodegroup
   if err != nil {
     log.Fatal(err)
   }
+
+Example of deleting a single cluster nodegroup
+
+  _, err := nodegroup.Delete(ctx, mksClient, clusterID, nodegroupID)
+  if err != nil {
+    log.Fatal(err)
+  }
 */
 package nodegroup

--- a/pkg/v1/nodegroup/requests.go
+++ b/pkg/v1/nodegroup/requests.go
@@ -79,3 +79,17 @@ func Create(ctx context.Context, client *v1.ServiceClient, clusterID string, opt
 
 	return responseResult, err
 }
+
+// Delete deletes a cluster nodegroup by its id.
+func Delete(ctx context.Context, client *v1.ServiceClient, clusterID, nodegroupID string) (*v1.ResponseResult, error) {
+	url := strings.Join([]string{client.Endpoint, v1.ResourceURLCluster, clusterID, v1.ResourceURLNodegroup, nodegroupID}, "/")
+	responseResult, err := client.DoRequest(ctx, http.MethodDelete, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if responseResult.Err != nil {
+		err = responseResult.Err
+	}
+
+	return responseResult, err
+}

--- a/pkg/v1/nodegroup/testing/requests_test.go
+++ b/pkg/v1/nodegroup/testing/requests_test.go
@@ -423,3 +423,109 @@ func TestCreateNodegroupTimeoutError(t *testing.T) {
 		t.Fatal("expected error from the Create method")
 	}
 }
+
+func TestDeleteNodegroup(t *testing.T) {
+	endpointCalled := false
+	testEnv := testutils.SetupTestEnv()
+	defer testEnv.TearDownTestEnv()
+
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
+		Mux:      testEnv.Mux,
+		URL:      "/v1/clusters/c1d7559c-55d8-4f65-9230-6a22b985ff93/nodegroups/b376745a-fbcb-413d-b418-180d059d79cd",
+		Method:   http.MethodDelete,
+		Status:   http.StatusNoContent,
+		CallFlag: &endpointCalled,
+	})
+
+	ctx := context.Background()
+	testClient := &v1.ServiceClient{
+		HTTPClient: &http.Client{},
+		TokenID:    testutils.TokenID,
+		Endpoint:   testEnv.Server.URL + "/v1",
+		UserAgent:  testutils.UserAgent,
+	}
+	clusterID := "c1d7559c-55d8-4f65-9230-6a22b985ff93"
+	nodegroupID := "b376745a-fbcb-413d-b418-180d059d79cd"
+
+	httpResponse, err := nodegroup.Delete(ctx, testClient, clusterID, nodegroupID)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !endpointCalled {
+		t.Fatal("endpoint wasn't called")
+	}
+	if httpResponse == nil {
+		t.Fatal("expected an HTTP response from the Delete method")
+	}
+	if httpResponse.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected %d status in the HTTP response, but got %d",
+			http.StatusNoContent, httpResponse.StatusCode)
+	}
+}
+
+func TestDeleteNodegroupHTTPError(t *testing.T) {
+	endpointCalled := false
+	testEnv := testutils.SetupTestEnv()
+	defer testEnv.TearDownTestEnv()
+
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/v1/clusters/c1d7559c-55d8-7f65-9230-6a22b985ff93/nodegroups/b376745a-0bcb-413d-b418-180d059d79cd",
+		RawResponse: testErrGenericResponseRaw,
+		Method:      http.MethodDelete,
+		Status:      http.StatusBadGateway,
+		CallFlag:    &endpointCalled,
+	})
+
+	ctx := context.Background()
+	testClient := &v1.ServiceClient{
+		HTTPClient: &http.Client{},
+		TokenID:    testutils.TokenID,
+		Endpoint:   testEnv.Server.URL + "/v1",
+		UserAgent:  testutils.UserAgent,
+	}
+	clusterID := "c1d7559c-55d8-7f65-9230-6a22b985ff93"
+	nodegroupID := "b376745a-0bcb-413d-b418-180d059d79cd"
+
+	httpResponse, err := nodegroup.Delete(ctx, testClient, clusterID, nodegroupID)
+
+	if !endpointCalled {
+		t.Fatal("endpoint wasn't called")
+	}
+	if httpResponse == nil {
+		t.Fatal("expected an HTTP response from the Delete method")
+	}
+	if err == nil {
+		t.Fatal("expected error from the Delete method")
+	}
+	if httpResponse.StatusCode != http.StatusBadGateway {
+		t.Fatalf("expected %d status in the HTTP response, but got %d",
+			http.StatusBadGateway, httpResponse.StatusCode)
+	}
+}
+
+func TestDeleteNodegroupTimeoutError(t *testing.T) {
+	testEnv := testutils.SetupTestEnv()
+	testEnv.Server.Close()
+	defer testEnv.TearDownTestEnv()
+
+	ctx := context.Background()
+	testClient := &v1.ServiceClient{
+		HTTPClient: &http.Client{},
+		TokenID:    testutils.TokenID,
+		Endpoint:   testEnv.Server.URL + "/v1",
+		UserAgent:  testutils.UserAgent,
+	}
+	clusterID := "c1e7559c-55d8-7f65-9230-6a22b985ff93"
+	nodegroupID := "b376845a-0bcb-413d-b418-180d059d79cd"
+
+	httpResponse, err := nodegroup.Delete(ctx, testClient, clusterID, nodegroupID)
+
+	if httpResponse != nil {
+		t.Fatal("expected no HTTP response from the Delete method")
+	}
+	if err == nil {
+		t.Fatal("expected error from the Delete method")
+	}
+}


### PR DESCRIPTION
Add method to delete a single cluster nodegroup.
Provide tests and doc example.

For #2 
