### PR TITLE
Cluster V1 - add nodegroup Resize method

### DIFF
--- a/pkg/v1/client.go
+++ b/pkg/v1/client.go
@@ -18,6 +18,7 @@ const (
 	ResourceURLRotateCerts = "rotate-certs"
 	ResourceURLTask        = "tasks"
 	ResourceURLNodegroup   = "nodegroups"
+	ResourceURLResize      = "resize"
 )
 
 const (

--- a/pkg/v1/nodegroup/doc.go
+++ b/pkg/v1/nodegroup/doc.go
@@ -42,5 +42,15 @@ Example of deleting a single cluster nodegroup
   if err != nil {
     log.Fatal(err)
   }
+
+Example of resizing a single cluster nodegroup
+
+  resizeOpts := &nodegroup.ResizeOpts{
+    Desired: 1,
+  }
+  _, err := nodegroup.Resize(ctx, mksClient, clusterID, nodegroupID, resizeOpts)
+  if err != nil {
+    log.Fatal(err)
+  }
 */
 package nodegroup

--- a/pkg/v1/nodegroup/requests.go
+++ b/pkg/v1/nodegroup/requests.go
@@ -93,3 +93,27 @@ func Delete(ctx context.Context, client *v1.ServiceClient, clusterID, nodegroupI
 
 	return responseResult, err
 }
+
+// Resize requests a resize of a cluster nodegroup by its id.
+func Resize(ctx context.Context, client *v1.ServiceClient, clusterID, nodegroupID string, opts *ResizeOpts) (*v1.ResponseResult, error) {
+	resizeNodegroupOpts := struct {
+		Nodegroup *ResizeOpts `json:"nodegroup"`
+	}{
+		Nodegroup: opts,
+	}
+	requestBody, err := json.Marshal(resizeNodegroupOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	url := strings.Join([]string{client.Endpoint, v1.ResourceURLCluster, clusterID, v1.ResourceURLNodegroup, nodegroupID, v1.ResourceURLResize}, "/")
+	responseResult, err := client.DoRequest(ctx, http.MethodPost, url, bytes.NewReader(requestBody))
+	if err != nil {
+		return nil, err
+	}
+	if responseResult.Err != nil {
+		err = responseResult.Err
+	}
+
+	return responseResult, err
+}

--- a/pkg/v1/nodegroup/requests_opts.go
+++ b/pkg/v1/nodegroup/requests_opts.go
@@ -37,3 +37,9 @@ type CreateOpts struct {
 	// AvailabilityZone should contain the valid zone in the selected region of the created cluster.
 	AvailabilityZone string `json:"availability_zone,omitempty"`
 }
+
+// ResizeOpts represents options for the nodegroup Resize request.
+type ResizeOpts struct {
+	// Desired represents desired amount of nodes for this nodegroup.
+	Desired int `json:"desired"`
+}

--- a/pkg/v1/nodegroup/testing/fixtures.go
+++ b/pkg/v1/nodegroup/testing/fixtures.go
@@ -142,6 +142,21 @@ var testCreateNodegroupOpts = &nodegroup.CreateOpts{
 	AvailabilityZone: "ru-1b",
 }
 
+// testResizeNodegroupOptsRaw represents marshalled options for the Resize request.
+const testResizeNodegroupOptsRaw = `
+{
+    "nodegroup": {
+        "desired": 1
+    }
+}
+`
+
+// nolint
+// testResizeNodegroupOpts represents options for the Resize request.
+var testResizeNodegroupOpts = &nodegroup.ResizeOpts{
+	Desired: 1,
+}
+
 // testManyNodegroupsInvalidResponseRaw represents a raw invalid response with several nodegroups.
 const testManyNodegroupsInvalidResponseRaw = `
 {


### PR DESCRIPTION
Add method to resize a single cluster nodegroup.
Provide tests and doc example.

For #2 
