### PR TITLE
Add Go 1.14 into Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ install:
   - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.3
 go:
   - "1.13"
+  - "1.14"
 script:
   - make tests
 after_success:


### PR DESCRIPTION
Run tests with 1.13 and with 1.14 Go versions.