### PR TITLE
V1: add os_server_id field into node View

### DIFF
--- a/pkg/v1/node/schemas.go
+++ b/pkg/v1/node/schemas.go
@@ -21,4 +21,7 @@ type View struct {
 
 	// NodegroupID contains nodegroup identifier.
 	NodegroupID string `json:"nodegroup_id"`
+
+	// OSServerID contains OpenStack server identifier.
+	OSServerID string `json:"os_server_id"`
 }

--- a/pkg/v1/node/testing/fixtures.go
+++ b/pkg/v1/node/testing/fixtures.go
@@ -15,6 +15,7 @@ const testGetNodeResponseRaw = `
         "id": "203d0f8c-547d-48a7-98ed-3075254b8d4a",
         "ip": "198.51.100.11",
         "nodegroup_id": "f174b65d-442a-4423-aaf7-5654789b8a9d",
+        "os_server_id": "dc56abe9-d0d4-4099-9b5f-e5cabfccf276",
         "updated_at": "2020-02-25T08:49:21.780542Z"
     }
 }
@@ -30,6 +31,7 @@ var expectedGetNodeResponse = &node.View{
 	Hostname:    "test-cluster-node-gap1g",
 	IP:          "198.51.100.11",
 	NodegroupID: "f174b65d-442a-4423-aaf7-5654789b8a9d",
+	OSServerID:  "dc56abe9-d0d4-4099-9b5f-e5cabfccf276",
 }
 
 // testSingleNodeInvalidResponseRaw represents a raw invalid response with a single node.

--- a/pkg/v1/nodegroup/testing/fixtures.go
+++ b/pkg/v1/nodegroup/testing/fixtures.go
@@ -24,6 +24,7 @@ const testGetNodegroupResponseRaw = `
                 "id": "39e5dd4d-5e23-4a00-8173-974bf844f21b",
                 "ip": "198.51.100.11",
                 "nodegroup_id": "a376745a-fbcb-413d-b418-169d059d79ce",
+                "os_server_id": "dc56abe9-d0d4-4099-9b5f-e5cabfccf276",
                 "updated_at": "2020-02-19T15:41:45.948646Z"
             }
         ],
@@ -66,6 +67,7 @@ var expectedGetNodegroupResponse = &nodegroup.View{
 			Hostname:    "test-cluster-node-eegp9",
 			IP:          "198.51.100.11",
 			NodegroupID: "a376745a-fbcb-413d-b418-169d059d79ce",
+			OSServerID:  "dc56abe9-d0d4-4099-9b5f-e5cabfccf276",
 		},
 	},
 	Labels: map[string]string{
@@ -98,6 +100,7 @@ const testListNodegroupsResponseRaw = `
                     "id": "39e5dd4d-5e23-4a00-8173-974bf844f21b",
                     "ip": "198.51.100.11",
                     "nodegroup_id": "a376745a-fbcb-413d-b418-169d059d79ce",
+                    "os_server_id": "dc56abe9-d0d4-4099-9b5f-e5cabfccf276",
                     "updated_at": "2020-02-19T15:41:45.948646Z"
                 }
             ],
@@ -140,6 +143,7 @@ var expectedListNodegroupsResponse = []*nodegroup.View{
 				Hostname:    "test-cluster-node-eegp9",
 				IP:          "198.51.100.11",
 				NodegroupID: "a376745a-fbcb-413d-b418-169d059d79ce",
+				OSServerID:  "dc56abe9-d0d4-4099-9b5f-e5cabfccf276",
 			},
 		},
 		Labels: map[string]string{


### PR DESCRIPTION
Add `os_server_id` field into node View in the node package.
Update testing fixtures.

For #51 
