### PR TITLE
V1: nodegroup autoscale support

### DIFF
--- a/pkg/testutils/ptr.go
+++ b/pkg/testutils/ptr.go
@@ -4,3 +4,8 @@ package testutils
 func BoolToPtr(v bool) *bool {
 	return &v
 }
+
+// IntToPtr can be used to convert integer value to integer pointer.
+func IntToPtr(v int) *int {
+	return &v
+}

--- a/pkg/v1/nodegroup/requests_opts.go
+++ b/pkg/v1/nodegroup/requests_opts.go
@@ -43,6 +43,16 @@ type CreateOpts struct {
 
 	// Taints represents a list of nodegroup taints.
 	Taints []Taint `json:"taints"`
+
+	// EnableAutoscale reflects if the nodegroup is allowed to be scaled automatically.
+	// Disabled by default.
+	EnableAutoscale *bool `json:"enable_autoscale,omitempty"`
+
+	// AutoscaleMinNodes represents minimum possible number of worker nodes in the nodegroup.
+	AutoscaleMinNodes *int `json:"autoscale_min_nodes,omitempty"`
+
+	// AutoscaleMaxNodes represents maximum possible number of worker nodes in the nodegroup.
+	AutoscaleMaxNodes *int `json:"autoscale_max_nodes,omitempty"`
 }
 
 // ResizeOpts represents options for the nodegroup Resize request.
@@ -56,4 +66,13 @@ type UpdateOpts struct {
 	// Labels represents an object containing a set of Kubernetes labels that will be applied
 	// for each node in the group. The keys must be user-defined.
 	Labels map[string]string `json:"labels"`
+
+	// EnableAutoscale reflects if the nodegroup is allowed to be scaled automatically.
+	EnableAutoscale *bool `json:"enable_autoscale,omitempty"`
+
+	// AutoscaleMinNodes represents minimum possible number of worker nodes in the nodegroup.
+	AutoscaleMinNodes *int `json:"autoscale_min_nodes,omitempty"`
+
+	// AutoscaleMaxNodes represents maximum possible number of worker nodes in the nodegroup.
+	AutoscaleMaxNodes *int `json:"autoscale_max_nodes,omitempty"`
 }

--- a/pkg/v1/nodegroup/schemas.go
+++ b/pkg/v1/nodegroup/schemas.go
@@ -44,6 +44,15 @@ type View struct {
 
 	// Taints represents a list of nodegroup taints.
 	Taints []Taint `json:"taints"`
+
+	// EnableAutoscale reflects if the nodegroup is allowed to be scaled automatically.
+	EnableAutoscale bool `json:"enable_autoscale"`
+
+	// AutoscaleMinNodes represents minimum possible number of worker nodes in the nodegroup.
+	AutoscaleMinNodes int `json:"autoscale_min_nodes"`
+
+	// AutoscaleMaxNodes represents maximum possible number of worker nodes in the nodegroup.
+	AutoscaleMaxNodes int `json:"autoscale_max_nodes"`
 }
 
 // TaintEffect represents an effect of the node's taint.

--- a/pkg/v1/nodegroup/schemas.go
+++ b/pkg/v1/nodegroup/schemas.go
@@ -6,6 +6,7 @@ import (
 	"github.com/selectel/mks-go/pkg/v1/node"
 )
 
+// nolint:maligned
 // View represents an unmarshalled nodegroup body from an API response.
 type View struct {
 	// ID is the identifier of the nodegroup.

--- a/pkg/v1/nodegroup/testing/fixtures.go
+++ b/pkg/v1/nodegroup/testing/fixtures.go
@@ -3,6 +3,7 @@ package testing
 import (
 	"time"
 
+	"github.com/selectel/mks-go/pkg/testutils"
 	"github.com/selectel/mks-go/pkg/v1/node"
 	"github.com/selectel/mks-go/pkg/v1/nodegroup"
 )
@@ -40,7 +41,10 @@ const testGetNodegroupResponseRaw = `
                 "value": "test-value-0",
                 "effect": "NoSchedule"
             }
-        ]
+        ],
+        "enable_autoscale": false,
+        "autoscale_min_nodes": 0,
+        "autoscale_max_nodes": 0
     }
 }
 `
@@ -80,6 +84,9 @@ var expectedGetNodegroupResponse = &nodegroup.View{
 			Effect: nodegroup.NoScheduleEffect,
 		},
 	},
+	EnableAutoscale:   false,
+	AutoscaleMinNodes: 0,
+	AutoscaleMaxNodes: 0,
 }
 
 // testListNodegroupsResponseRaw represents a raw response from the List method.
@@ -116,7 +123,10 @@ const testListNodegroupsResponseRaw = `
                     "value": "test-value-0",
                     "effect": "NoSchedule"
                 }
-            ]
+            ],
+            "enable_autoscale": false,
+            "autoscale_min_nodes": 0,
+            "autoscale_max_nodes": 0
         }
     ]
 }
@@ -156,6 +166,9 @@ var expectedListNodegroupsResponse = []*nodegroup.View{
 				Effect: nodegroup.NoScheduleEffect,
 			},
 		},
+		EnableAutoscale:   false,
+		AutoscaleMinNodes: 0,
+		AutoscaleMaxNodes: 0,
 	},
 }
 
@@ -179,7 +192,10 @@ const testCreateNodegroupOptsRaw = `
             "value": "test-value-0",
             "effect": "NoSchedule"
           }
-        ]
+        ],
+        "enable_autoscale": true,
+        "autoscale_min_nodes": 1,
+        "autoscale_max_nodes": 10
     }
 }
 `
@@ -204,6 +220,9 @@ var testCreateNodegroupOpts = &nodegroup.CreateOpts{
 			Effect: nodegroup.NoScheduleEffect,
 		},
 	},
+	EnableAutoscale:   testutils.BoolToPtr(true),
+	AutoscaleMinNodes: testutils.IntToPtr(1),
+	AutoscaleMaxNodes: testutils.IntToPtr(10),
 }
 
 // testUpdateNodegroupOptsRaw represents marshalled options for the Update request.
@@ -212,7 +231,8 @@ const testUpdateNodegroupOptsRaw = `
     "nodegroup": {
         "labels": {
           "test-label-key": "test-label-value"
-        }
+        },
+        "enable_autoscale": false
     }
 }
 `
@@ -223,6 +243,7 @@ var testUpdateNodegroupOpts = &nodegroup.UpdateOpts{
 	Labels: map[string]string{
 		"test-label-key": "test-label-value",
 	},
+	EnableAutoscale: testutils.BoolToPtr(false),
 }
 
 // testResizeNodegroupOptsRaw represents marshalled options for the Resize request.


### PR DESCRIPTION
Add EnableAutoscale, AutoscaleMinNodes, AutoscaleMaxNodes fields
into View, CreateOpts and UpdateOpts structs in the nodegroup package.

Update testing fixtures.

Add IntToPtr helper in testutils package.

For #51 
