### PR TITLE
Cluster V1 - add node Delete method

### DIFF
--- a/pkg/v1/node/doc.go
+++ b/pkg/v1/node/doc.go
@@ -16,5 +16,12 @@ Example of reinstalling a single node of a cluster nodegroup by its id
   if err != nil {
     log.Fatal(err)
   }
+
+Example of deleting a single node of a cluster nodegroup by its id
+
+  _, err := node.Delete(ctx, mksClient, clusterID, nodegroupID, nodeID)
+  if err != nil {
+    log.Fatal(err)
+  }
 */
 package node

--- a/pkg/v1/node/requests.go
+++ b/pkg/v1/node/requests.go
@@ -44,3 +44,17 @@ func Reinstall(ctx context.Context, client *v1.ServiceClient, clusterID, nodegro
 
 	return responseResult, err
 }
+
+// Delete deletes a node of a cluster nodegroup by its id.
+func Delete(ctx context.Context, client *v1.ServiceClient, clusterID, nodegroupID, nodeID string) (*v1.ResponseResult, error) {
+	url := strings.Join([]string{client.Endpoint, v1.ResourceURLCluster, clusterID, v1.ResourceURLNodegroup, nodegroupID, nodeID}, "/")
+	responseResult, err := client.DoRequest(ctx, http.MethodDelete, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if responseResult.Err != nil {
+		err = responseResult.Err
+	}
+
+	return responseResult, err
+}

--- a/pkg/v1/node/testing/requests_test.go
+++ b/pkg/v1/node/testing/requests_test.go
@@ -279,3 +279,112 @@ func TestReinstallNodeTimeoutError(t *testing.T) {
 		t.Fatal("expected error from the Reinstall method")
 	}
 }
+
+func TestDeleteNode(t *testing.T) {
+	endpointCalled := false
+	testEnv := testutils.SetupTestEnv()
+	defer testEnv.TearDownTestEnv()
+
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
+		Mux:      testEnv.Mux,
+		URL:      "/v1/clusters/892de51c-54b9-49fa-af0e-7f547bce788a/nodegroups/c195b65d-442a-4423-aaf7-5654789b8a9d/d1800f8c-547d-48a7-98ed-3075254b8d4a",
+		Method:   http.MethodDelete,
+		Status:   http.StatusNoContent,
+		CallFlag: &endpointCalled,
+	})
+
+	ctx := context.Background()
+	testClient := &v1.ServiceClient{
+		HTTPClient: &http.Client{},
+		TokenID:    testutils.TokenID,
+		Endpoint:   testEnv.Server.URL + "/v1",
+		UserAgent:  testutils.UserAgent,
+	}
+	clusterID := "892de51c-54b9-49fa-af0e-7f547bce788a"
+	nodegroupID := "c195b65d-442a-4423-aaf7-5654789b8a9d"
+	nodeID := "d1800f8c-547d-48a7-98ed-3075254b8d4a"
+
+	httpResponse, err := node.Delete(ctx, testClient, clusterID, nodegroupID, nodeID)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !endpointCalled {
+		t.Fatal("endpoint wasn't called")
+	}
+	if httpResponse == nil {
+		t.Fatal("expected an HTTP response from the Delete method")
+	}
+	if httpResponse.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected %d status in the HTTP response, but got %d",
+			http.StatusNoContent, httpResponse.StatusCode)
+	}
+}
+
+func TestDeleteNodeHTTPError(t *testing.T) {
+	endpointCalled := false
+	testEnv := testutils.SetupTestEnv()
+	defer testEnv.TearDownTestEnv()
+
+	testutils.HandleReqWithoutBody(t, &testutils.HandleReqOpts{
+		Mux:         testEnv.Mux,
+		URL:         "/v1/clusters/892de71c-3700-49fa-bc4e-7f547bce788a/nodegroups/d174b68d-442a-4423-aaf7-5654789b8a9d/c03ce18c-547d-48a7-98ed-3075254b8d4a",
+		RawResponse: testErrGenericResponseRaw,
+		Method:      http.MethodDelete,
+		Status:      http.StatusBadGateway,
+		CallFlag:    &endpointCalled,
+	})
+
+	ctx := context.Background()
+	testClient := &v1.ServiceClient{
+		HTTPClient: &http.Client{},
+		TokenID:    testutils.TokenID,
+		Endpoint:   testEnv.Server.URL + "/v1",
+		UserAgent:  testutils.UserAgent,
+	}
+	clusterID := "892de71c-3700-49fa-bc4e-7f547bce788a"
+	nodegroupID := "d174b68d-442a-4423-aaf7-5654789b8a9d"
+	nodeID := "c03ce18c-547d-48a7-98ed-3075254b8d4a"
+
+	httpResponse, err := node.Delete(ctx, testClient, clusterID, nodegroupID, nodeID)
+
+	if !endpointCalled {
+		t.Fatal("endpoint wasn't called")
+	}
+	if httpResponse == nil {
+		t.Fatal("expected an HTTP response from the Delete method")
+	}
+	if err == nil {
+		t.Fatal("expected error from the Delete method")
+	}
+	if httpResponse.StatusCode != http.StatusBadGateway {
+		t.Fatalf("expected %d status in the HTTP response, but got %d",
+			http.StatusBadGateway, httpResponse.StatusCode)
+	}
+}
+
+func TestDeleteNodeTimeoutError(t *testing.T) {
+	testEnv := testutils.SetupTestEnv()
+	testEnv.Server.Close()
+	defer testEnv.TearDownTestEnv()
+
+	ctx := context.Background()
+	testClient := &v1.ServiceClient{
+		HTTPClient: &http.Client{},
+		TokenID:    testutils.TokenID,
+		Endpoint:   testEnv.Server.URL + "/v1",
+		UserAgent:  testutils.UserAgent,
+	}
+	clusterID := "18ed321c-3700-49fa-af0e-7f547bce788a"
+	nodegroupID := "2174b55d-442a-41e3-aaf7-5b54789b8a9d"
+	nodeID := "3cdc0f8c-327d-48a7-98ed-3075254b8d4a"
+
+	httpResponse, err := node.Delete(ctx, testClient, clusterID, nodegroupID, nodeID)
+
+	if httpResponse != nil {
+		t.Fatal("expected no HTTP response from the Delete method")
+	}
+	if err == nil {
+		t.Fatal("expected error from the Delete method")
+	}
+}


### PR DESCRIPTION
Add method to delete a single node of a cluster nodegroup.
Provide tests and doc example.

For #51 
