### PR TITLE
V1: allow to init service client with custom http

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,7 @@ linters:
     - bodyclose
     - dupl
     - gochecknoglobals
+    - gomnd
     - gosec
     - lll
     - wsl

--- a/pkg/v1/client.go
+++ b/pkg/v1/client.go
@@ -85,6 +85,20 @@ func NewMKSClientV1(tokenID, endpoint string) *ServiceClient {
 	}
 }
 
+// NewMKSClientV1WithCustomHTTP initializes a new MKS client for the V1 API using custom HTTP client.
+// If custom HTTP client is nil - default HTTP client will be used.
+func NewMKSClientV1WithCustomHTTP(customHTTPClient *http.Client, tokenID, endpoint string) *ServiceClient {
+	if customHTTPClient == nil {
+		customHTTPClient = newHTTPClient()
+	}
+	return &ServiceClient{
+		HTTPClient: customHTTPClient,
+		TokenID:    tokenID,
+		Endpoint:   endpoint,
+		UserAgent:  userAgent,
+	}
+}
+
 // newHTTPClient returns a reference to an initialized and configured HTTP client.
 func newHTTPClient() *http.Client {
 	return &http.Client{

--- a/pkg/v1/client_test.go
+++ b/pkg/v1/client_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/selectel/mks-go/pkg/testutils"
 )
@@ -22,6 +23,34 @@ func TestNewMKSClientV1(t *testing.T) {
 	}
 
 	actual := NewMKSClientV1(tokenID, endpoint)
+
+	if expected.TokenID != actual.TokenID {
+		t.Errorf("expected Endpoint %s, but got %s", expected.Endpoint, actual.Endpoint)
+	}
+	if expected.Endpoint != actual.Endpoint {
+		t.Errorf("expected TokenID %s, but got %s", expected.TokenID, actual.TokenID)
+	}
+	if expected.UserAgent != actual.UserAgent {
+		t.Errorf("expected UserAgent %s, but got %s", expected.UserAgent, actual.UserAgent)
+	}
+	if actual.HTTPClient == nil {
+		t.Errorf("expected initialized HTTPClient but it's nil")
+	}
+}
+
+func TestNewMKSClientV1WithCustomHTTP(t *testing.T) {
+	tokenID := testutils.TokenID
+	endpoint := "http://example.org"
+	expected := &ServiceClient{
+		TokenID:   tokenID,
+		Endpoint:  endpoint,
+		UserAgent: userAgent,
+	}
+	customHTTPClient := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+
+	actual := NewMKSClientV1WithCustomHTTP(customHTTPClient, tokenID, endpoint)
 
 	if expected.TokenID != actual.TokenID {
 		t.Errorf("expected Endpoint %s, but got %s", expected.Endpoint, actual.Endpoint)


### PR DESCRIPTION
Add new method that initializes a new MKS V1 client with custom
http settings.
Update tests.

