### PR TITLE
Make linters great again

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,7 @@ linters:
   disable-all: true
   enable:
     - asciicheck
-#    - cyclop
+    - cyclop
     - deadcode
     - depguard
     - dogsled

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,7 +38,7 @@ linters:
     - misspell
     - nakedret
     - nestif
-#    - nilerr
+    - nilerr
 #    - nlreturn
     - noctx
     - nolintlint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,15 +1,74 @@
 linters:
   fast: false
-  enable-all: true
-  disable:
-    - bodyclose
-    - dupl
+  disable-all: true
+  enable:
+    - asciicheck
+#    - cyclop
+    - deadcode
+    - depguard
+    - dogsled
+    - durationcheck
+    - errcheck
+    - errname
+    - errorlint
+#    - exhaustive
+    - exportloopref
+    - forbidigo
+    - forcetypeassert
+    - funlen
+    - gci
+    - goconst
     - gochecknoglobals
-    - gomnd
-    - gosec
-    - lll
-    - wsl
+    - gocritic
+    - godot
+#    - goerr113
+    - gofmt
+    - gofumpt
+    - goheader
+    - goimports
+    - gomoddirectives
+    - gomodguard
+    - goprintffuncname
+    - gosimple
+    - govet
+    - ifshort
+    - importas
+    - ineffassign
+    - makezero
+    - misspell
+    - nakedret
+    - nestif
+#    - nilerr
+#    - nlreturn
+    - noctx
+    - nolintlint
+    - prealloc
+    - predeclared
+    - promlinter
+    - revive
+    - staticcheck
+    - structcheck
+    - stylecheck
+#    - tagliatelle
+    - tparallel
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - wastedassign
+    - whitespace
 
 linters-settings:
   funlen:
-    statements: 42
+    statements: 65
+
+  tagliatelle:
+    case:
+      use-field-name: false
+      rules:
+        json: snake
+
+run:
+  skip-files:
+    - "fixtures.go"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,7 +39,7 @@ linters:
     - nakedret
     - nestif
     - nilerr
-#    - nlreturn
+    - nlreturn
     - noctx
     - nolintlint
     - prealloc

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,7 @@ linters:
     - errcheck
     - errname
     - errorlint
-#    - exhaustive
+    - exhaustive
     - exportloopref
     - forbidigo
     - forcetypeassert

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: go
 install:
   - go get github.com/mattn/goveralls
   - go get github.com/wadey/gocovmerge
-  - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.3
+  - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.43.0
 go:
-  - "1.13"
-  - "1.14"
+  - "1.16"
+  - "1.17"
 script:
   - make tests
 after_success:

--- a/Earthfile
+++ b/Earthfile
@@ -1,16 +1,30 @@
-linter-1.13:
-    FROM golang:1.13
+linters-1.16:
+    FROM golang:1.16
     DO +LINTER_CMDS
 
-linter-1.14:
-    FROM golang:1.14
+linters-1.17:
+    FROM golang:1.17
     DO +LINTER_CMDS
+
+tests-1.16:
+    FROM golang:1.16
+    DO +TEST_CMDS
+
+tests-1.17:
+    FROM golang:1.17
+    DO +TEST_CMDS
+
+TEST_CMDS:
+    COMMAND
+    WORKDIR /mks-go
+    COPY . .
+    RUN go get github.com/mattn/goveralls; \
+        go get github.com/wadey/gocovmerge
+    RUN make unittest
 
 LINTER_CMDS:
     COMMAND
     WORKDIR /mks-go
     COPY . .
-    RUN go get github.com/mattn/goveralls; \
-        go get github.com/wadey/gocovmerge; \
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.3
+    RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.43.0
     RUN make golangci-lint

--- a/pkg/testutils/environment.go
+++ b/pkg/testutils/environment.go
@@ -15,6 +15,7 @@ type TestEnv struct {
 func SetupTestEnv() *TestEnv {
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)
+
 	return &TestEnv{
 		Mux:    mux,
 		Server: server,

--- a/pkg/v1/client.go
+++ b/pkg/v1/client.go
@@ -93,6 +93,7 @@ func NewMKSClientV1WithCustomHTTP(customHTTPClient *http.Client, tokenID, endpoi
 	if customHTTPClient == nil {
 		customHTTPClient = newHTTPClient()
 	}
+
 	return &ServiceClient{
 		HTTPClient: customHTTPClient,
 		TokenID:    tokenID,
@@ -228,6 +229,7 @@ func (result *ResponseResult) extractErr() error {
 
 	if len(body) == 0 {
 		result.Err = fmt.Errorf(errGotHTTPStatusCodeFmt, result.StatusCode)
+
 		return nil
 	}
 	if result.StatusCode == http.StatusNotFound {
@@ -237,6 +239,7 @@ func (result *ResponseResult) extractErr() error {
 	}
 	if result.ErrNotFound == nil || result.ErrGeneric == nil {
 		result.Err = fmt.Errorf(errGotHTTPStatusCodeFmt, result.StatusCode)
+
 		return nil
 	}
 

--- a/pkg/v1/client.go
+++ b/pkg/v1/client.go
@@ -237,7 +237,7 @@ func (result *ResponseResult) extractErr() error {
 	} else {
 		_ = json.Unmarshal(body, &result.ErrGeneric)
 	}
-	if result.ErrNotFound == nil || result.ErrGeneric == nil {
+	if result.ErrNotFound == nil && result.ErrGeneric == nil {
 		result.Err = fmt.Errorf(errGotHTTPStatusCodeFmt, result.StatusCode)
 
 		return nil

--- a/pkg/v1/client.go
+++ b/pkg/v1/client.go
@@ -231,11 +231,11 @@ func (result *ResponseResult) extractErr() error {
 		return nil
 	}
 	if result.StatusCode == http.StatusNotFound {
-		err = json.Unmarshal(body, &result.ErrNotFound)
+		_ = json.Unmarshal(body, &result.ErrNotFound)
 	} else {
-		err = json.Unmarshal(body, &result.ErrGeneric)
+		_ = json.Unmarshal(body, &result.ErrGeneric)
 	}
-	if err != nil {
+	if result.ErrNotFound == nil || result.ErrGeneric == nil {
 		result.Err = fmt.Errorf(errGotHTTPStatusCodeFmt, result.StatusCode)
 		return nil
 	}

--- a/pkg/v1/cluster/schemas.go
+++ b/pkg/v1/cluster/schemas.go
@@ -27,6 +27,25 @@ const (
 	StatusUnknown                            Status = "UNKNOWN"
 )
 
+func getSupportedStatuses() []Status {
+	return []Status{
+		StatusActive, StatusPendingCreate, StatusPendingUpdate, StatusPendingUpgrade, StatusPendingRotateCerts,
+		StatusPendingDelete, StatusPendingResize, StatusPendingNodeReinstall, StatusPendingUpgradePatchVersion,
+		StatusPendingUpgradeMinorVersion, StatusPendingUpdateNodegroup, StatusPendingUpgradeMastersConfiguration,
+		StatusPendingUpgradeClusterConfiguration, StatusMaintenance, StatusError, StatusUnknown,
+	}
+}
+
+func isStatusSupported(s Status) bool {
+	for _, v := range getSupportedStatuses() {
+		if s == v {
+			return true
+		}
+	}
+
+	return false
+}
+
 // View represents an unmarshalled cluster body from an API response.
 type View struct {
 	// ID is the identifier of the cluster.
@@ -103,52 +122,20 @@ func (result *View) UnmarshalJSON(b []byte) error {
 		tmp
 		Status Status `json:"status"`
 	}
-	err := json.Unmarshal(b, &s)
-	if err != nil {
+	if err := json.Unmarshal(b, &s); err != nil {
 		return err
 	}
 
 	*result = View(s.tmp)
 
 	// Check cluster status.
-	switch s.Status {
-	case StatusActive:
-		result.Status = StatusActive
-	case StatusPendingCreate:
-		result.Status = StatusPendingCreate
-	case StatusPendingUpdate:
-		result.Status = StatusPendingUpdate
-	case StatusPendingUpgrade:
-		result.Status = StatusPendingUpgrade
-	case StatusPendingRotateCerts:
-		result.Status = StatusPendingRotateCerts
-	case StatusPendingDelete:
-		result.Status = StatusPendingDelete
-	case StatusPendingResize:
-		result.Status = StatusPendingResize
-	case StatusPendingNodeReinstall:
-		result.Status = StatusPendingNodeReinstall
-	case StatusPendingUpgradePatchVersion:
-		result.Status = StatusPendingUpgradePatchVersion
-	case StatusPendingUpgradeMinorVersion:
-		result.Status = StatusPendingUpgradeMinorVersion
-	case StatusPendingUpdateNodegroup:
-		result.Status = StatusPendingUpdateNodegroup
-	case StatusPendingUpgradeMastersConfiguration:
-		result.Status = StatusPendingUpgradeMastersConfiguration
-	case StatusPendingUpgradeClusterConfiguration:
-		result.Status = StatusPendingUpgradeClusterConfiguration
-	case StatusMaintenance:
-		result.Status = StatusMaintenance
-	case StatusError:
-		result.Status = StatusError
-	case StatusUnknown:
-		result.Status = StatusUnknown
-	default:
+	if isStatusSupported(s.Status) {
+		result.Status = s.Status
+	} else {
 		result.Status = StatusUnknown
 	}
 
-	return err
+	return nil
 }
 
 // KubernetesOptions represents additional k8s options such as pod security policy,

--- a/pkg/v1/cluster/schemas.go
+++ b/pkg/v1/cluster/schemas.go
@@ -142,6 +142,8 @@ func (result *View) UnmarshalJSON(b []byte) error {
 		result.Status = StatusMaintenance
 	case StatusError:
 		result.Status = StatusError
+	case StatusUnknown:
+		result.Status = StatusUnknown
 	default:
 		result.Status = StatusUnknown
 	}

--- a/pkg/v1/cluster/schemas.go
+++ b/pkg/v1/cluster/schemas.go
@@ -29,10 +29,21 @@ const (
 
 func getSupportedStatuses() []Status {
 	return []Status{
-		StatusActive, StatusPendingCreate, StatusPendingUpdate, StatusPendingUpgrade, StatusPendingRotateCerts,
-		StatusPendingDelete, StatusPendingResize, StatusPendingNodeReinstall, StatusPendingUpgradePatchVersion,
-		StatusPendingUpgradeMinorVersion, StatusPendingUpdateNodegroup, StatusPendingUpgradeMastersConfiguration,
-		StatusPendingUpgradeClusterConfiguration, StatusMaintenance, StatusError, StatusUnknown,
+		StatusActive,
+		StatusPendingCreate,
+		StatusPendingUpdate,
+		StatusPendingUpgrade,
+		StatusPendingRotateCerts,
+		StatusPendingDelete,
+		StatusPendingResize,
+		StatusPendingNodeReinstall,
+		StatusPendingUpgradePatchVersion,
+		StatusPendingUpgradeMinorVersion,
+		StatusPendingUpdateNodegroup,
+		StatusPendingUpgradeMastersConfiguration,
+		StatusPendingUpgradeClusterConfiguration,
+		StatusMaintenance,
+		StatusError,
 	}
 }
 

--- a/pkg/v1/cluster/schemas.go
+++ b/pkg/v1/cluster/schemas.go
@@ -163,7 +163,7 @@ type KubernetesOptions struct {
 	AdmissionControllers []string `json:"admission_controllers"`
 }
 
-// KubeconfigFields is a struct that contains Kubeconfigs parsed fields and raw kubeconfig
+// KubeconfigFields is a struct that contains Kubeconfigs parsed fields and raw kubeconfig.
 type KubeconfigFields struct {
 	ClusterCA     string
 	Server        string

--- a/pkg/v1/cluster/testing/fixtures.go
+++ b/pkg/v1/cluster/testing/fixtures.go
@@ -627,7 +627,8 @@ var expectedListClustersResponse = []*cluster.View{
 		KubernetesOptions: &cluster.KubernetesOptions{
 			EnablePodSecurityPolicy: false,
 			FeatureGates:            []string{"CSIMigrationOpenStack"},
-			AdmissionControllers:    []string{"LimitRanger"}},
+			AdmissionControllers:    []string{"LimitRanger"},
+		},
 	},
 	{
 		ID:                            "3be7559b-55d8-4f65-9230-6a22b985ff73",
@@ -652,7 +653,8 @@ var expectedListClustersResponse = []*cluster.View{
 		KubernetesOptions: &cluster.KubernetesOptions{
 			EnablePodSecurityPolicy: false,
 			FeatureGates:            []string{"CSIMigrationOpenStack"},
-			AdmissionControllers:    []string{"LimitRanger"}},
+			AdmissionControllers:    []string{"LimitRanger"},
+		},
 	},
 	{
 		ID:                            "4be7559b-55d8-4f65-9230-6a22b985ff73",
@@ -677,7 +679,8 @@ var expectedListClustersResponse = []*cluster.View{
 		KubernetesOptions: &cluster.KubernetesOptions{
 			EnablePodSecurityPolicy: false,
 			FeatureGates:            []string{"CSIMigrationOpenStack"},
-			AdmissionControllers:    []string{"LimitRanger"}},
+			AdmissionControllers:    []string{"LimitRanger"},
+		},
 	},
 	{
 		ID:                            "5be7559b-55d8-4f65-9230-6a22b985ff73",
@@ -702,7 +705,8 @@ var expectedListClustersResponse = []*cluster.View{
 		KubernetesOptions: &cluster.KubernetesOptions{
 			EnablePodSecurityPolicy: false,
 			FeatureGates:            []string{"CSIMigrationOpenStack"},
-			AdmissionControllers:    []string{"LimitRanger"}},
+			AdmissionControllers:    []string{"LimitRanger"},
+		},
 	},
 	{
 		ID:                            "6be7559b-55d8-4f65-9230-6a22b985ff73",
@@ -727,7 +731,8 @@ var expectedListClustersResponse = []*cluster.View{
 		KubernetesOptions: &cluster.KubernetesOptions{
 			EnablePodSecurityPolicy: false,
 			FeatureGates:            []string{"CSIMigrationOpenStack"},
-			AdmissionControllers:    []string{"LimitRanger"}},
+			AdmissionControllers:    []string{"LimitRanger"},
+		},
 	},
 	{
 		ID:                            "7be7559b-55d8-4f65-9230-6a22b985ff73",
@@ -752,7 +757,8 @@ var expectedListClustersResponse = []*cluster.View{
 		KubernetesOptions: &cluster.KubernetesOptions{
 			EnablePodSecurityPolicy: false,
 			FeatureGates:            []string{"CSIMigrationOpenStack"},
-			AdmissionControllers:    []string{"LimitRanger"}},
+			AdmissionControllers:    []string{"LimitRanger"},
+		},
 	},
 	{
 		ID:                            "8be7559b-55d8-4f65-9230-6a22b985ff73",
@@ -777,7 +783,8 @@ var expectedListClustersResponse = []*cluster.View{
 		KubernetesOptions: &cluster.KubernetesOptions{
 			EnablePodSecurityPolicy: false,
 			FeatureGates:            []string{"CSIMigrationOpenStack"},
-			AdmissionControllers:    []string{"LimitRanger"}},
+			AdmissionControllers:    []string{"LimitRanger"},
+		},
 	},
 	{
 		ID:                            "9be7559b-55d8-4f65-9230-6a22b985ff73",
@@ -802,7 +809,8 @@ var expectedListClustersResponse = []*cluster.View{
 		KubernetesOptions: &cluster.KubernetesOptions{
 			EnablePodSecurityPolicy: false,
 			FeatureGates:            []string{"CSIMigrationOpenStack"},
-			AdmissionControllers:    []string{"LimitRanger"}},
+			AdmissionControllers:    []string{"LimitRanger"},
+		},
 	},
 	{
 		ID:                            "9be7559b-55d8-4f65-9230-6a22b985ff73",
@@ -827,7 +835,8 @@ var expectedListClustersResponse = []*cluster.View{
 		KubernetesOptions: &cluster.KubernetesOptions{
 			EnablePodSecurityPolicy: false,
 			FeatureGates:            []string{"CSIMigrationOpenStack"},
-			AdmissionControllers:    []string{"LimitRanger"}},
+			AdmissionControllers:    []string{"LimitRanger"},
+		},
 	},
 	{
 		ID:                            "9be7559b-55d8-4f65-9230-6a22b985ff73",
@@ -852,7 +861,8 @@ var expectedListClustersResponse = []*cluster.View{
 		KubernetesOptions: &cluster.KubernetesOptions{
 			EnablePodSecurityPolicy: false,
 			FeatureGates:            []string{"CSIMigrationOpenStack"},
-			AdmissionControllers:    []string{"LimitRanger"}},
+			AdmissionControllers:    []string{"LimitRanger"},
+		},
 	},
 	{
 		ID:                            "9be7559b-55d8-4f65-9230-6a22b985ff73",
@@ -877,7 +887,8 @@ var expectedListClustersResponse = []*cluster.View{
 		KubernetesOptions: &cluster.KubernetesOptions{
 			EnablePodSecurityPolicy: false,
 			FeatureGates:            []string{"CSIMigrationOpenStack"},
-			AdmissionControllers:    []string{"LimitRanger"}},
+			AdmissionControllers:    []string{"LimitRanger"},
+		},
 	},
 	{
 		ID:                            "9be7559b-55d8-4f65-9230-6a22b985ff73",
@@ -902,7 +913,8 @@ var expectedListClustersResponse = []*cluster.View{
 		KubernetesOptions: &cluster.KubernetesOptions{
 			EnablePodSecurityPolicy: false,
 			FeatureGates:            []string{"CSIMigrationOpenStack"},
-			AdmissionControllers:    []string{"LimitRanger"}},
+			AdmissionControllers:    []string{"LimitRanger"},
+		},
 	},
 	{
 		ID:                            "10e7559b-55d8-4f65-9230-6a22b985ff73",
@@ -927,7 +939,8 @@ var expectedListClustersResponse = []*cluster.View{
 		KubernetesOptions: &cluster.KubernetesOptions{
 			EnablePodSecurityPolicy: false,
 			FeatureGates:            []string{"CSIMigrationOpenStack"},
-			AdmissionControllers:    []string{"LimitRanger"}},
+			AdmissionControllers:    []string{"LimitRanger"},
+		},
 	},
 	{
 		ID:                            "117559b-55d8-4f65-9230-6a22b985ff73",
@@ -952,7 +965,8 @@ var expectedListClustersResponse = []*cluster.View{
 		KubernetesOptions: &cluster.KubernetesOptions{
 			EnablePodSecurityPolicy: false,
 			FeatureGates:            []string{"CSIMigrationOpenStack"},
-			AdmissionControllers:    []string{"LimitRanger"}},
+			AdmissionControllers:    []string{"LimitRanger"},
+		},
 	},
 	{
 		ID:                            "12e7559b-55d8-4f65-9230-6a22b985ff73",
@@ -1023,7 +1037,6 @@ const testCreateClusterOptsRaw = `
 }
 `
 
-// nolint
 // testCreateClusterOpts represents options for the Create request.
 var testCreateClusterOpts = &cluster.CreateOpts{
 	Name:        "test-cluster-0",
@@ -1150,7 +1163,6 @@ const testCreateClusterEnableBoolsOptsRaw = `
 }
 `
 
-// nolint
 // testCreateClusterEnableBoolsOpts represents options for the Create request with enabled booleans opts.
 var testCreateClusterEnableBoolsOpts = &cluster.CreateOpts{
 	Name:                          "test-cluster-0",
@@ -1205,7 +1217,6 @@ const testCreateClusterDisableBoolsOptsRaw = `
 }
 `
 
-// nolint
 // testCreateClusterDisableBoolsOpts represents options for the Create request with disabled booleans opts.
 var testCreateClusterDisableBoolsOpts = &cluster.CreateOpts{
 	Name:                          "test-cluster-0",
@@ -1311,7 +1322,6 @@ const testCreateZonalClusterOptsRaw = `
 }
 `
 
-// nolint
 // testCreateZonalClusterOpts represents options for the Create request with zonal attribute set to true.
 var testCreateZonalClusterOpts = &cluster.CreateOpts{
 	Name:        "test-zonal-cluster-0",

--- a/pkg/v1/cluster/testing/requests_test.go
+++ b/pkg/v1/cluster/testing/requests_test.go
@@ -35,7 +35,6 @@ func TestGetCluster(t *testing.T) {
 	id := "dbe7559b-55d8-4f65-9230-6a22b985ff73"
 
 	actual, httpResponse, err := cluster.Get(ctx, testClient, id)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -78,7 +77,6 @@ func TestGetZonalCluster(t *testing.T) {
 	id := "763f1f5f-951e-48b2-abae-815a75ee747c"
 
 	actual, httpResponse, err := cluster.Get(ctx, testClient, id)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -229,7 +227,6 @@ func TestListClusters(t *testing.T) {
 	}
 
 	actual, httpResponse, err := cluster.List(ctx, testClient)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -378,7 +375,6 @@ func TestCreateCluster(t *testing.T) {
 	}
 
 	actual, httpResponse, err := cluster.Create(ctx, testClient, testCreateClusterOpts)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -421,7 +417,6 @@ func TestCreateClusterEnableBools(t *testing.T) {
 	}
 
 	actual, httpResponse, err := cluster.Create(ctx, testClient, testCreateClusterEnableBoolsOpts)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -464,7 +459,6 @@ func TestCreateClusterDisableBools(t *testing.T) {
 	}
 
 	actual, httpResponse, err := cluster.Create(ctx, testClient, testCreateClusterDisableBoolsOpts)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -507,7 +501,6 @@ func TestCreateZonalCluster(t *testing.T) {
 	}
 
 	actual, httpResponse, err := cluster.Create(ctx, testClient, testCreateZonalClusterOpts)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -659,7 +652,6 @@ func TestUpdateCluster(t *testing.T) {
 	id := "57b244b4-a49e-4067-a837-e0024a3a8aed"
 
 	actual, httpResponse, err := cluster.Update(ctx, testClient, id, testUpdateClusterOpts)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -812,7 +804,6 @@ func TestDeleteCluster(t *testing.T) {
 	id := "dbe7559c-55d8-4f65-9230-6a22b985ff73"
 
 	httpResponse, err := cluster.Delete(ctx, testClient, id)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1163,7 +1154,6 @@ func TestRotateCerts(t *testing.T) {
 	id := "dbe1259c-55d8-4f65-9230-6a22b985ff73"
 
 	httpResponse, err := cluster.RotateCerts(ctx, testClient, id)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1267,7 +1257,6 @@ func TestUpgradePatchVersion(t *testing.T) {
 	id := "fc1d8841-d8dc-4981-a97f-4cb251e3a8aa"
 
 	actual, httpResponse, err := cluster.UpgradePatchVersion(ctx, testClient, id)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1419,7 +1408,6 @@ func TestUpgradeMinorVersion(t *testing.T) {
 	id := "dbe7559b-55d8-4f65-9230-6a22b985ff16"
 
 	actual, httpResponse, err := cluster.UpgradeMinorVersion(ctx, testClient, id)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1572,7 +1560,6 @@ func TestUpdateClusterEnablePSP(t *testing.T) {
 	id := "effe751d-501a-4b06-8e23-3f686dbfccf6"
 
 	actual, httpResponse, err := cluster.Update(ctx, testClient, id, testUpdateClusterWithEnabledPSPOpts)
-
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/v1/kubeoptions/testing/requests_test.go
+++ b/pkg/v1/kubeoptions/testing/requests_test.go
@@ -34,7 +34,6 @@ func TestListFeatureGates(t *testing.T) {
 	}
 
 	actual, httpResponse, err := kubeoptions.ListFeatureGates(ctx, testClient)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -140,7 +139,6 @@ func TestListAdmissionControllers(t *testing.T) {
 	}
 
 	actual, httpResponse, err := kubeoptions.ListAdmissionControllers(ctx, testClient)
-
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/v1/kubeversion/testing/requests_test.go
+++ b/pkg/v1/kubeversion/testing/requests_test.go
@@ -34,7 +34,6 @@ func TestListKubeVersions(t *testing.T) {
 	}
 
 	actual, httpResponse, err := kubeversion.List(ctx, testClient)
-
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/v1/node/testing/requests_test.go
+++ b/pkg/v1/node/testing/requests_test.go
@@ -37,7 +37,6 @@ func TestGetNode(t *testing.T) {
 	nodeID := "203d0f8c-547d-48a7-98ed-3075254b8d4a"
 
 	actual, httpResponse, err := node.Get(ctx, testClient, clusterID, nodegroupID, nodeID)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -196,7 +195,6 @@ func TestReinstallNode(t *testing.T) {
 	nodeID := "c1800f8c-547d-48a7-98ed-3075254b8d4a"
 
 	httpResponse, err := node.Reinstall(ctx, testClient, clusterID, nodegroupID, nodeID)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -305,7 +303,6 @@ func TestDeleteNode(t *testing.T) {
 	nodeID := "d1800f8c-547d-48a7-98ed-3075254b8d4a"
 
 	httpResponse, err := node.Delete(ctx, testClient, clusterID, nodegroupID, nodeID)
-
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/v1/nodegroup/testing/fixtures.go
+++ b/pkg/v1/nodegroup/testing/fixtures.go
@@ -51,7 +51,6 @@ const testGetNodegroupResponseRaw = `
 
 var nodegroupResponseTimestamp, _ = time.Parse(time.RFC3339, "2020-02-19T15:41:45.948646Z")
 
-// nolint
 // expectedGetNodegroupResponse represents an unmarshalled testGetNodegroupResponseRaw.
 var expectedGetNodegroupResponse = &nodegroup.View{
 	ID:               "a376745a-fbcb-413d-b418-169d059d79ce",
@@ -132,7 +131,6 @@ const testListNodegroupsResponseRaw = `
 }
 `
 
-// nolint
 // expectedListNodegroupsResponse represents an unmarshalled testListNodegroupsResponseRaw.
 var expectedListNodegroupsResponse = []*nodegroup.View{
 	{
@@ -200,7 +198,6 @@ const testCreateNodegroupOptsRaw = `
 }
 `
 
-// nolint
 // testCreateNodegroupOpts represents options for the Create request.
 var testCreateNodegroupOpts = &nodegroup.CreateOpts{
 	Count:            1,
@@ -237,7 +234,6 @@ const testUpdateNodegroupOptsRaw = `
 }
 `
 
-// nolint
 // testCreateNodegroupOpts represents options for the Update request.
 var testUpdateNodegroupOpts = &nodegroup.UpdateOpts{
 	Labels: map[string]string{
@@ -255,7 +251,6 @@ const testResizeNodegroupOptsRaw = `
 }
 `
 
-// nolint
 // testResizeNodegroupOpts represents options for the Resize request.
 var testResizeNodegroupOpts = &nodegroup.ResizeOpts{
 	Desired: 1,

--- a/pkg/v1/nodegroup/testing/requests_test.go
+++ b/pkg/v1/nodegroup/testing/requests_test.go
@@ -36,7 +36,6 @@ func TestGetNodegroup(t *testing.T) {
 	nodegroupID := "a376745a-fbcb-413d-b418-169d059d79ce"
 
 	actual, httpResponse, err := nodegroup.Get(ctx, testClient, clusterID, nodegroupID)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -191,7 +190,6 @@ func TestListNodegroups(t *testing.T) {
 	clusterID := "79265515-3700-49fa-af0e-7f547bce788a"
 
 	actual, httpResponse, err := nodegroup.List(ctx, testClient, clusterID)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -343,7 +341,6 @@ func TestCreateNodegroup(t *testing.T) {
 	clusterID := "d1465515-3700-49fa-af0e-7f547bce788a"
 
 	httpResponse, err := nodegroup.Create(ctx, testClient, clusterID, testCreateNodegroupOpts)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -448,7 +445,6 @@ func TestDeleteNodegroup(t *testing.T) {
 	nodegroupID := "b376745a-fbcb-413d-b418-180d059d79cd"
 
 	httpResponse, err := nodegroup.Delete(ctx, testClient, clusterID, nodegroupID)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -555,7 +551,6 @@ func TestResizeNodegroup(t *testing.T) {
 	nodegroupID := "c476d45a-0bcc-e13d-b418-180d059d79cd"
 
 	httpResponse, err := nodegroup.Resize(ctx, testClient, clusterID, nodegroupID, testResizeNodegroupOpts)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -663,7 +658,6 @@ func TestUpdateNodegroup(t *testing.T) {
 	nodegroupID := "c476d45a-0bcc-e13d-b418-180d059d79cd"
 
 	httpResponse, err := nodegroup.Update(ctx, testClient, clusterID, nodegroupID, testUpdateNodegroupOpts)
-
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/v1/task/schemas.go
+++ b/pkg/v1/task/schemas.go
@@ -15,6 +15,20 @@ const (
 	StatusUnknown    Status = "UNKNOWN"
 )
 
+func getSupportedStatuses() []Status {
+	return []Status{StatusInProgress, StatusDone, StatusError, StatusUnknown}
+}
+
+func isSupportedStatus(s Status) bool {
+	for _, v := range getSupportedStatuses() {
+		if s == v {
+			return true
+		}
+	}
+
+	return false
+}
+
 // Type represents custom type for various task types.
 type Type string
 
@@ -32,6 +46,24 @@ const (
 	TypeUpgradeClusterConfiguration Type = "UPGRADE_CLUSTER_CONFIGURATION"
 	TypeUnknown                     Type = "UNKNOWN"
 )
+
+func getSupportedTaskTypes() []Type {
+	return []Type{
+		TypeCreateCluster, TypeDeleteCluster, TypeRotateCerts, TypeNodeGroupResize,
+		TypeNodeReinstall, TypeClusterResize, TypeUpgradePatchVersion, TypeUpgradeMinorVersion,
+		TypeUpdateNodegroupLabels, TypeUpgradeMastersConfiguration, TypeUpgradeClusterConfiguration, TypeUnknown,
+	}
+}
+
+func isTaskTypeSupported(t Type) bool {
+	for _, v := range getSupportedTaskTypes() {
+		if t == v {
+			return true
+		}
+	}
+
+	return false
+}
 
 // View represents an unmarshalled cluster task body from an API response.
 type View struct {
@@ -61,56 +93,25 @@ func (result *View) UnmarshalJSON(b []byte) error {
 		Status Status `json:"status"`
 		Type   Type   `json:"type"`
 	}
-	err := json.Unmarshal(b, &s)
-	if err != nil {
+	if err := json.Unmarshal(b, &s); err != nil {
 		return err
 	}
 
 	*result = View(s.tmp)
 
 	// Check task status.
-	switch s.Status {
-	case StatusDone:
-		result.Status = StatusDone
-	case StatusInProgress:
-		result.Status = StatusInProgress
-	case StatusError:
-		result.Status = StatusError
-	case StatusUnknown:
-		result.Status = StatusUnknown
-	default:
+	if isSupportedStatus(s.Status) {
+		result.Status = s.Status
+	} else {
 		result.Status = StatusUnknown
 	}
 
 	// Check task type.
-	switch s.Type {
-	case TypeCreateCluster:
-		result.Type = TypeCreateCluster
-	case TypeDeleteCluster:
-		result.Type = TypeDeleteCluster
-	case TypeRotateCerts:
-		result.Type = TypeRotateCerts
-	case TypeNodeGroupResize:
-		result.Type = TypeNodeGroupResize
-	case TypeNodeReinstall:
-		result.Type = TypeNodeReinstall
-	case TypeClusterResize:
-		result.Type = TypeClusterResize
-	case TypeUpgradePatchVersion:
-		result.Type = TypeUpgradePatchVersion
-	case TypeUpgradeMinorVersion:
-		result.Type = TypeUpgradeMinorVersion
-	case TypeUpdateNodegroupLabels:
-		result.Type = TypeUpdateNodegroupLabels
-	case TypeUpgradeMastersConfiguration:
-		result.Type = TypeUpgradeMastersConfiguration
-	case TypeUpgradeClusterConfiguration:
-		result.Type = TypeUpgradeClusterConfiguration
-	case TypeUnknown:
-		result.Type = TypeUnknown
-	default:
+	if isTaskTypeSupported(s.Type) {
+		result.Type = s.Type
+	} else {
 		result.Type = TypeUnknown
 	}
 
-	return err
+	return nil
 }

--- a/pkg/v1/task/schemas.go
+++ b/pkg/v1/task/schemas.go
@@ -16,7 +16,11 @@ const (
 )
 
 func getSupportedStatuses() []Status {
-	return []Status{StatusInProgress, StatusDone, StatusError, StatusUnknown}
+	return []Status{
+		StatusInProgress,
+		StatusDone,
+		StatusError,
+	}
 }
 
 func isSupportedStatus(s Status) bool {
@@ -49,9 +53,17 @@ const (
 
 func getSupportedTaskTypes() []Type {
 	return []Type{
-		TypeCreateCluster, TypeDeleteCluster, TypeRotateCerts, TypeNodeGroupResize,
-		TypeNodeReinstall, TypeClusterResize, TypeUpgradePatchVersion, TypeUpgradeMinorVersion,
-		TypeUpdateNodegroupLabels, TypeUpgradeMastersConfiguration, TypeUpgradeClusterConfiguration, TypeUnknown,
+		TypeCreateCluster,
+		TypeDeleteCluster,
+		TypeRotateCerts,
+		TypeNodeGroupResize,
+		TypeNodeReinstall,
+		TypeClusterResize,
+		TypeUpgradePatchVersion,
+		TypeUpgradeMinorVersion,
+		TypeUpdateNodegroupLabels,
+		TypeUpgradeMastersConfiguration,
+		TypeUpgradeClusterConfiguration,
 	}
 }
 

--- a/pkg/v1/task/schemas.go
+++ b/pkg/v1/task/schemas.go
@@ -76,6 +76,8 @@ func (result *View) UnmarshalJSON(b []byte) error {
 		result.Status = StatusInProgress
 	case StatusError:
 		result.Status = StatusError
+	case StatusUnknown:
+		result.Status = StatusUnknown
 	default:
 		result.Status = StatusUnknown
 	}
@@ -104,6 +106,8 @@ func (result *View) UnmarshalJSON(b []byte) error {
 		result.Type = TypeUpgradeMastersConfiguration
 	case TypeUpgradeClusterConfiguration:
 		result.Type = TypeUpgradeClusterConfiguration
+	case TypeUnknown:
+		result.Type = TypeUnknown
 	default:
 		result.Type = TypeUnknown
 	}

--- a/pkg/v1/task/testing/requests_test.go
+++ b/pkg/v1/task/testing/requests_test.go
@@ -36,7 +36,6 @@ func TestGetTask(t *testing.T) {
 	taskID := "2f6fb93c-cf0d-4289-a78c-34393ac75f92"
 
 	actual, httpResponse, err := task.Get(ctx, testClient, clusterID, taskID)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -192,7 +191,6 @@ func TestGetTaskUnknownStatusAndType(t *testing.T) {
 	taskID := "2f6fb93c-cf0d-4289-a78c-34393ac75f92"
 
 	actual, httpResponse, err := task.Get(ctx, testClient, clusterID, taskID)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -235,7 +233,6 @@ func TestListTasks(t *testing.T) {
 	clusterID := "d2e16a48-a9c5-4449-9b71-81f21fc872db"
 
 	actual, httpResponse, err := task.List(ctx, testClient, clusterID)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -387,7 +384,6 @@ func TestListTasksUnknownStatusAndType(t *testing.T) {
 	clusterID := "d1e16a48-a9c5-4449-9b71-81f21fc872cb"
 
 	actual, httpResponse, err := task.List(ctx, testClient, clusterID)
-
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/scripts/gotest.sh
+++ b/scripts/gotest.sh
@@ -3,7 +3,7 @@
 echo "==> Running go test and creating a coverage profile..."
 i=0
 failed=0
-for testingpkg in $(go list ./pkg/.../testing); do
+for testingpkg in $(go list ./pkg/.../testing ./pkg/v1); do
   coverpkg=${testingpkg::-8}
   go test -v -covermode count -coverprofile "./${i}.coverprofile" -coverpkg $coverpkg $testingpkg
   if [ $? -eq 1 ]; then


### PR DESCRIPTION
Fix linters and bump versions for go and golangci-lint for CI.
Also add client_test.go to tests that run during CI pipeline.